### PR TITLE
Make momentum a scalar quantity, and add direction vector

### DIFF
--- a/inc/GenInfo.hh
+++ b/inc/GenInfo.hh
@@ -16,16 +16,16 @@ namespace mu2e
   struct GenInfo {
     Int_t _pdg, _gen; // true PDG code, generator code
     Float_t _time;  // time of this step
-    XYZVec _dir;   // direction at the start of this step
     Float_t _mom; // scalar momentum at the start of this step
+    Float_t _costh; // cos(theta), where theta is angle between particle's momentum and z-axis
+    Float_t _phi;   // azimuthal angle of particle's momentum vector
     XYZVec _pos;  // particle position at the start of this step
     GenInfo() { reset(); }
-    void reset() { _pdg = _gen = -1; _time = -1.0; _dir=XYZVec(); _mom = 0; _pos = XYZVec(); }
-    static std::string leafnames() { static std::string leaves; 
-      leaves = std::string("pdg/I:gen/I:t0/F:")+Geom::XYZnames("dir") + std::string(":mom/F:") + Geom::XYZnames("pos");
+    void reset() { _pdg = _gen = -1; _time = -1.0; _mom = 0; _costh = 0; _phi = 0; _pos = XYZVec(); }
+    static std::string leafnames() { static std::string leaves;
+      leaves = std::string("pdg/I:gen/I:t0/F:mom/F:costh/F:phi/F:") + Geom::XYZnames("pos");
       return leaves;
     }
-  };  
+  };
 }
 #endif
-

--- a/inc/GenInfo.hh
+++ b/inc/GenInfo.hh
@@ -16,12 +16,13 @@ namespace mu2e
   struct GenInfo {
     Int_t _pdg, _gen; // true PDG code, generator code
     Float_t _time;  // time of this step
-    XYZVec _mom;   // momentum at the start of this step
+    XYZVec _dir;   // direction at the start of this step
+    Float_t _mom; // scalar momentum at the start of this step
     XYZVec _pos;  // particle position at the start of this step
     GenInfo() { reset(); }
-    void reset() { _pdg = _gen = -1; _time = -1.0; _mom=XYZVec(); _pos = XYZVec(); }
+    void reset() { _pdg = _gen = -1; _time = -1.0; _dir=XYZVec(); _mom = 0; _pos = XYZVec(); }
     static std::string leafnames() { static std::string leaves; 
-      leaves = std::string("pdg/I:gen/I:t0/F:")+Geom::XYZnames("mom") + std::string(":") + Geom::XYZnames("pos");
+      leaves = std::string("pdg/I:gen/I:t0/F:")+Geom::XYZnames("dir") + std::string(":mom/F:") + Geom::XYZnames("pos");
       return leaves;
     }
   };  

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -70,19 +70,20 @@ namespace mu2e
     Int_t _pdg, _gen, _proc; // true PDG code, generator code, and process code of the primary particle
     Float_t _otime;  // origin time
     XYZVec _opos;  // origin position
-    XYZVec _odir; // original direction
     Float_t _omom;   // origin momentum (scalar)
+    Float_t _ocosth; // origin cos(theta), where theta is the angle between the particle's momentum and z-axis
+    Float_t _ophi; // origin phi (azimuthal angle of particle's momentum vector)
     MCRelationship _prel; // relationship if this tracks primary particle to the event primary
  
     TrkInfoMC() { reset(); }
     void reset() { _ndigi = _ndigigood = _nactive = _nhits = _nambig = _pdg = _gen  = _proc= -1;  _otime=0.0;
       _prel = MCRelationship();
-      _opos = _odir = XYZVec();
-      _omom = -1;
+      _opos = XYZVec();
+      _omom = -1, _ocosth = -1, _ophi=-1;
     }
     static std::string leafnames() { static std::string leaves; leaves =
       std::string("ndigi/I:ndigigood/I:nhits/I:nactive/I:nambig/I:pdg/I:gen/I:proc/I:otime/F:")
-    + Geom::XYZnames("opos") + std::string(":") + Geom::XYZnames("odir") + std::string(":omom/F:prel/B:prem/B");
+    + Geom::XYZnames("opos") + std::string(":omom/F:ocosth/F:ophi/F:prel/B:prem/B");
 
       return leaves;
     }
@@ -90,14 +91,15 @@ namespace mu2e
 //  MC information about a particle for a specific point/time
   struct TrkInfoMCStep {
     Float_t _time;  // time of this step
-    XYZVec _dir;   // direction of particle at the start of this step
     Float_t _mom; // scalar momentum of particle at the start of this step
+    Float_t _costh; // cos(theta) of momentum vector of particles at the start of this step (theta is angle between momentum vector and z-axis)
+    Float_t _phi; // azimuthal angle of momentum vector
     XYZVec _pos;  // particle position at the start of this step
     helixpar _hpar; // helix parameters corresponding to the particle position and momentum assuming the nominal BField
     TrkInfoMCStep() { reset(); }
-    void reset() { _time = -1; _dir=XYZVec(); _mom = -1; _pos = XYZVec(); _hpar.reset(); }
+    void reset() { _time = -1; _mom = -1; _costh = -1; _phi = -1; _pos = XYZVec(); _hpar.reset(); }
     static std::string leafnames() { static std::string leaves; leaves =
-      std::string("t0/F:")+Geom::XYZnames("dir") + std::string(":mom/F:") + Geom::XYZnames("pos") + std::string(":")+helixpar::leafnames();
+      std::string("t0/F:mom/F:costh/F:phi/F:") + Geom::XYZnames("pos") + std::string(":")+helixpar::leafnames();
       return leaves;
     }
   };
@@ -119,7 +121,6 @@ namespace mu2e
       std::string("pdg/I:t/F:e/F:posx/F:posy/F:posz/F:momx/F:momy/F:momz/F");
       return leaves;
     }
-  };  
-  
+  };
 }
 #endif

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -77,7 +77,9 @@ namespace mu2e
     TrkInfoMC() { reset(); }
     void reset() { _ndigi = _ndigigood = _nactive = _nhits = _nambig = _pdg = _gen  = _proc= -1;  _otime=0.0;
       _prel = MCRelationship();
-      _opos = _odir = XYZVec(); _omom = -1;}
+      _opos = _odir = XYZVec();
+      _omom = -1;
+    }
     static std::string leafnames() { static std::string leaves; leaves =
       std::string("ndigi/I:ndigigood/I:nhits/I:nactive/I:nambig/I:pdg/I:gen/I:proc/I:otime/F:")
     + Geom::XYZnames("opos") + std::string(":") + Geom::XYZnames("odir") + std::string(":omom/F:prel/B:prem/B");

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -70,17 +70,17 @@ namespace mu2e
     Int_t _pdg, _gen, _proc; // true PDG code, generator code, and process code of the primary particle
     Float_t _otime;  // origin time
     XYZVec _opos;  // origin position
-    XYZVec _omom;   // origin momentum
+    XYZVec _odir; // original direction
+    Float_t _omom;   // origin momentum (scalar)
     MCRelationship _prel; // relationship if this tracks primary particle to the event primary
  
     TrkInfoMC() { reset(); }
     void reset() { _ndigi = _ndigigood = _nactive = _nhits = _nambig = _pdg = _gen  = _proc= -1;  _otime=0.0;
       _prel = MCRelationship();
-      _opos = _omom = XYZVec(); }
+      _opos = _odir = XYZVec(); _omom = -1;}
     static std::string leafnames() { static std::string leaves; leaves =
-      std::string("ndigi/I:ndigigood/I:nhits/I:nactive/I:nambig/I:pdg/I:gen/I:proc/I:otime/F:") 
-	+ Geom::XYZnames("opos") + std::string(":") + Geom::XYZnames("omom") 
-	+ std::string(":prel/B:prem/B");
+      std::string("ndigi/I:ndigigood/I:nhits/I:nactive/I:nambig/I:pdg/I:gen/I:proc/I:otime/F:")
+    + Geom::XYZnames("opos") + std::string(":") + Geom::XYZnames("odir") + std::string(":omom/F:prel/B:prem/B");
 
       return leaves;
     }
@@ -88,13 +88,14 @@ namespace mu2e
 //  MC information about a particle for a specific point/time
   struct TrkInfoMCStep {
     Float_t _time;  // time of this step
-    XYZVec _mom;   // momentum at the start of this step
+    XYZVec _dir;   // direction of particle at the start of this step
+    Float_t _mom; // scalar momentum of particle at the start of this step
     XYZVec _pos;  // particle position at the start of this step
     helixpar _hpar; // helix parameters corresponding to the particle position and momentum assuming the nominal BField
     TrkInfoMCStep() { reset(); }
-    void reset() { _time = -1; _mom=XYZVec(); _pos = XYZVec(); _hpar.reset(); }
+    void reset() { _time = -1; _dir=XYZVec(); _mom = -1; _pos = XYZVec(); _hpar.reset(); }
     static std::string leafnames() { static std::string leaves; leaves =
-      std::string("t0/F:")+Geom::XYZnames("mom") + std::string(":") + Geom::XYZnames("pos") + std::string(":")+helixpar::leafnames();
+      std::string("t0/F:")+Geom::XYZnames("dir") + std::string(":mom/F:") + Geom::XYZnames("pos") + std::string(":")+helixpar::leafnames();
       return leaves;
     }
   };
@@ -120,4 +121,3 @@ namespace mu2e
   
 }
 #endif
-

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -40,7 +40,8 @@ namespace mu2e {
     GeomHandle<DetectorSystem> det;
     trkinfomc._otime = trkprimary->startGlobalTime() + _toff.totalTimeOffset(trkprimary);
     trkinfomc._opos = Geom::toXYZVec(det->toDetector(trkprimary->startPosition()));
-    trkinfomc._omom = Geom::toXYZVec(trkprimary->startMomentum());
+    trkinfomc._odir = Geom::toXYZVec(trkprimary->startMomentum().vect().unit());
+    trkinfomc._omom = trkprimary->startMomentum().vect().mag();
   }
 
   void InfoMCStructHelper::fillTrkInfoMCDigis(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc) {
@@ -135,7 +136,8 @@ namespace mu2e {
     const auto& genParticle = primary.primary();
     priinfo._pdg = genParticle.pdgId();
     priinfo._gen = genParticle.generatorId().id();
-    priinfo._mom = Geom::toXYZVec(genParticle.momentum());
+    priinfo._dir = Geom::toXYZVec(genParticle.momentum().vect().unit());
+    priinfo._mom = genParticle.momentum().vect().mag();
     priinfo._pos = Geom::toXYZVec(det->toDetector(genParticle.position()));
     priinfo._time = genParticle.time(); // NB doesn't have time offsets applied
   }
@@ -147,7 +149,8 @@ namespace mu2e {
     if(gp.isNonnull()){
       geninfo._pdg = gp->pdgId();
       geninfo._gen = gp->generatorId().id();
-      geninfo._mom = Geom::toXYZVec(gp->momentum());
+      geninfo._dir = Geom::toXYZVec(gp->momentum().vect().unit());
+      geninfo._mom = gp->momentum().vect().mag();
       geninfo._pos = Geom::toXYZVec(det->toDetector(gp->position()));
       geninfo._time = gp->time(); // NB doesn't have time offsets applied
     }
@@ -173,7 +176,8 @@ namespace mu2e {
 	  if(fabs(target_time - corrected_time) < dmin){
 	    dmin = fabs(target_time - corrected_time);//i_mcstep._time;
 	    trkinfomcstep._time = i_mcstep._time;
-	    trkinfomcstep._mom = Geom::Hep3Vec(i_mcstep._mom);
+	    trkinfomcstep._dir = Geom::Hep3Vec(i_mcstep._mom.unit());
+	    trkinfomcstep._mom = std::sqrt(i_mcstep._mom.mag2());
 	    trkinfomcstep._pos = Geom::Hep3Vec(i_mcstep._pos);
 
 	    CLHEP::HepVector parvec(5,0);

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -40,8 +40,9 @@ namespace mu2e {
     GeomHandle<DetectorSystem> det;
     trkinfomc._otime = trkprimary->startGlobalTime() + _toff.totalTimeOffset(trkprimary);
     trkinfomc._opos = Geom::toXYZVec(det->toDetector(trkprimary->startPosition()));
-    trkinfomc._odir = Geom::toXYZVec(trkprimary->startMomentum().vect().unit());
     trkinfomc._omom = trkprimary->startMomentum().vect().mag();
+    trkinfomc._ocosth = std::cos(trkprimary->startMomentum().vect().theta());
+    trkinfomc._ophi = trkprimary->startMomentum().vect().phi();
   }
 
   void InfoMCStructHelper::fillTrkInfoMCDigis(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc) {
@@ -136,8 +137,9 @@ namespace mu2e {
     const auto& genParticle = primary.primary();
     priinfo._pdg = genParticle.pdgId();
     priinfo._gen = genParticle.generatorId().id();
-    priinfo._dir = Geom::toXYZVec(genParticle.momentum().vect().unit());
     priinfo._mom = genParticle.momentum().vect().mag();
+    priinfo._costh = std::cos(genParticle.momentum().vect().theta());
+    priinfo._phi = genParticle.momentum().vect().phi();
     priinfo._pos = Geom::toXYZVec(det->toDetector(genParticle.position()));
     priinfo._time = genParticle.time(); // NB doesn't have time offsets applied
   }
@@ -149,8 +151,9 @@ namespace mu2e {
     if(gp.isNonnull()){
       geninfo._pdg = gp->pdgId();
       geninfo._gen = gp->generatorId().id();
-      geninfo._dir = Geom::toXYZVec(gp->momentum().vect().unit());
       geninfo._mom = gp->momentum().vect().mag();
+      geninfo._costh = std::cos(gp->momentum().vect().theta());
+      geninfo._phi = gp->momentum().vect().phi();
       geninfo._pos = Geom::toXYZVec(det->toDetector(gp->position()));
       geninfo._time = gp->time(); // NB doesn't have time offsets applied
     }
@@ -176,8 +179,9 @@ namespace mu2e {
 	  if(fabs(target_time - corrected_time) < dmin){
 	    dmin = fabs(target_time - corrected_time);//i_mcstep._time;
 	    trkinfomcstep._time = i_mcstep._time;
-	    trkinfomcstep._dir = Geom::Hep3Vec(i_mcstep._mom.unit());
 	    trkinfomcstep._mom = std::sqrt(i_mcstep._mom.mag2());
+	    trkinfomcstep._costh = std::cos(i_mcstep._mom.theta());
+	    trkinfomcstep._phi = i_mcstep._mom.phi();
 	    trkinfomcstep._pos = Geom::Hep3Vec(i_mcstep._pos);
 
 	    CLHEP::HepVector parvec(5,0);


### PR DESCRIPTION
We want to standardize momentum as a scalar quantity in TrkAna. This PR implements the necessary changes for the MC branches (the reco branches already have momentum as a scalar quantity). All *.momx, *.momy, and *,momz branches have been replaced by *.mom, *.costh, *.phi.

Here is the list of leaf changes in the trkana tree created by TrkAnaReco.fcl:
 - momentum of `StepPointMC` at entrance, middle and exit of tracker:
     - `demcent.momx`, `demcent.momy`, `demcent.momz` -> `demcent.mom`, `demcent.costh`, `demcent.phi`
     - `demcmid.momx`, `demcmid.momy`, `demcmid.momz` -> `demcmid.mom`, `demcmid.costh`, `demcmid.phi`
     - `demcxit.momx`, `demcxit.momy`, `demcxit.momz` -> `demcxit.mom`, `demcxit.costh`, `demcxit.phi`
 - momentum of `GenParticle`:
     - `demcgen.momx`, `demcgen.momy`, `demcgen.momz` -> `demcgen.mom`, `demcgen.costh`, `demcgen.phi`
 - momentum of `PrimaryParticle`:
     - `demcpri.momx`, `demcpri.momy`, `demcpri.momz` -> `demcpri.mom`, `demcpri.costh`, `demcpri.phi`
 - initial momentum of `SimParticle` that produced track:
     - `demc.omomx`, `demc.omomy`, `demc.omomz` -> `demc.omom`, `demc.ocosth`, `demc.ophi`