### PR TITLE
Adding fcl file for use with output of ceSimReco

### DIFF
--- a/fcl/TrkAnaReco_ceSimReco.fcl
+++ b/fcl/TrkAnaReco_ceSimReco.fcl
@@ -1,0 +1,12 @@
+#include "TrkAna/fcl/TrkAnaReco.fcl"
+
+process_name : TrkAnaCeSimReco
+
+physics.analyzers.TrkAnaNeg.supplements : [  ]
+physics.analyzers.TrkAnaPos.supplements : [  ]
+
+physics.analyzers.TrkAnaNeg.FillTriggerInfo : false
+physics.TrkAnaTrigPath : [ PBIWeight, TrkQualDeM, TrkPIDDeM ]
+physics.TrkAnaEndPath : [ TrkAnaNeg, genCountLogger ]
+
+services.TFileService.fileName: "nts.owner.trkana-ce-sim-reco.version.sequencer.root"


### PR DESCRIPTION
A few times people have tried to use TrkAnaReco.fcl with the output of ceSimReco.fcl. Unfortuntaely, it doesn't work because ceSimReco.fcl only runs the downstream e-minus reconstruction. In this PR I have added a fcl file for use with the output of ceSimReco. This will be ideal for students who might be asked to run ceSimReco as a first task to get used to the code.