### PR TITLE
Updated Genealogy Info

### DIFF
--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -168,6 +168,7 @@ BEGIN_PROLOG
 	     trkpid : "TrkPID"
 	     fillTrkPID : true
 	     fillHits : true
+	     genealogyDepth : 5
   }
 
   DeM : { input : "KFF" 

--- a/inc/CaloClusterInfoMC.hh
+++ b/inc/CaloClusterInfoMC.hh
@@ -5,7 +5,7 @@
 #ifndef CaloClusterInfoMC_HH
 #define CaloClusterInfoMC_HH
 #include "Rtypes.h"
-#include "DataProducts/inc/XYZVec.hh"
+#include "DataProducts/inc/GenVector.hh"
 #include "MCDataProducts/inc/MCRelationship.hh"
 namespace mu2e 
 {

--- a/inc/GenInfo.hh
+++ b/inc/GenInfo.hh
@@ -6,12 +6,12 @@
 // 
 #ifndef GenInfo_HH
 #define GenInfo_HH
-#include "Offline/DataProducts/inc/XYZVec.hh"
+#include "Offline/DataProducts/inc/GenVector.hh"
 #include "TrkAna/inc/helixpar.hh"
+#include "TrkAna/inc/Names.hh"
 #include "Rtypes.h"
 namespace mu2e
 {
-
 // general info about the gen particle which was simulated
   struct GenInfo {
     Int_t _pdg, _gen; // true PDG code, generator code
@@ -19,11 +19,11 @@ namespace mu2e
     Float_t _mom; // scalar momentum at the start of this step
     Float_t _costh; // cos(theta), where theta is angle between particle's momentum and z-axis
     Float_t _phi;   // azimuthal angle of particle's momentum vector
-    XYZVec _pos;  // particle position at the start of this step
+    XYZVectorF _pos;  // particle position at the start of this step
     GenInfo() { reset(); }
-    void reset() { _pdg = _gen = -1; _time = -1.0; _mom = 0; _costh = 0; _phi = 0; _pos = XYZVec(); }
+    void reset() { _pdg = _gen = -1; _time = -1.0; _mom = 0; _costh = 0; _phi = 0; _pos = XYZVectorF(); }
     static std::string leafnames() { static std::string leaves;
-      leaves = std::string("pdg/I:gen/I:t0/F:mom/F:costh/F:phi/F:") + Geom::XYZnames("pos");
+      leaves = std::string("pdg/I:gen/I:t0/F:mom/F:costh/F:phi/F:") + Names::XYZnames("pos");
       return leaves;
     }
   };

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -11,7 +11,7 @@
 
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "TrkAna/inc/TrkInfo.hh"
-#include "TrkAna/inc/GenInfo.hh"
+#include "TrkAna/inc/SimInfo.hh"
 #include "TrkAna/inc/TrkStrawHitInfoMC.hh"
 #include "TrkAna/inc/CaloClusterInfoMC.hh"
 #include "Offline/MCDataProducts/inc/KalSeedMC.hh"
@@ -32,8 +32,8 @@ namespace mu2e {
     SimParticleTimeOffset _toff;
     double _mingood;
 
-    void fillGenInfo(const art::Ptr<SimParticle>& sp, GenInfo& geninfo);
-    void fillGenInfo(const SimParticle& sp, GenInfo& geninfo);
+    void fillSimInfo(const art::Ptr<SimParticle>& sp, SimInfo& siminfo);
+    void fillSimInfo(const SimParticle& sp, SimInfo& siminfo);
 
   public:
 
@@ -58,7 +58,7 @@ namespace mu2e {
     void fillTrkInfoMC(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc);
     void fillTrkInfoMCDigis(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc);
     void fillHitInfoMC(const KalSeedMC& kseedmc, TrkStrawHitInfoMC& tshinfomc, const TrkStrawHitMC& tshmc);
-    void fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo, GenInfo& gparentinfo);
+    void fillSimAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, SimInfo& priinfo, SimInfo& siminfo, SimInfo& parentinfo, SimInfo& gparentinfo);
     void fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep, std::vector<int> const& vids, double target_time);
 
     void fillHitInfoMCs(const KalSeedMC& kseedmc, std::vector<TrkStrawHitInfoMC>& tshinfomcs);

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -58,7 +58,8 @@ namespace mu2e {
     void fillTrkInfoMC(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc);
     void fillTrkInfoMCDigis(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc);
     void fillHitInfoMC(const KalSeedMC& kseedmc, TrkStrawHitInfoMC& tshinfomc, const TrkStrawHitMC& tshmc);
-    void fillSimAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, SimInfo& priinfo, SimInfo& siminfo, SimInfo& parentinfo, SimInfo& gparentinfo);
+    void fillAllSimInfos(const KalSeedMC& kseedmc, std::vector<SimInfo>& siminfos, int n_generations);
+    void fillPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, SimInfo& priinfo);
     void fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep, std::vector<int> const& vids, double target_time);
 
     void fillHitInfoMCs(const KalSeedMC& kseedmc, std::vector<TrkStrawHitInfoMC>& tshinfomcs);

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -57,7 +57,7 @@ namespace mu2e {
     void fillTrkInfoMC(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc);
     void fillTrkInfoMCDigis(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc);
     void fillHitInfoMC(const KalSeedMC& kseedmc, TrkStrawHitInfoMC& tshinfomc, const TrkStrawHitMC& tshmc);
-    void fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo);
+    void fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo);
     void fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep, std::vector<int> const& vids, double target_time);
 
     void fillHitInfoMCs(const KalSeedMC& kseedmc, std::vector<TrkStrawHitInfoMC>& tshinfomcs);

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -33,6 +33,7 @@ namespace mu2e {
     double _mingood;
 
     void fillGenInfo(const art::Ptr<SimParticle>& sp, GenInfo& geninfo);
+    void fillGenInfo(const SimParticle& sp, GenInfo& geninfo);
 
   public:
 
@@ -57,7 +58,7 @@ namespace mu2e {
     void fillTrkInfoMC(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc);
     void fillTrkInfoMCDigis(const KalSeedMC& kseedmc, TrkInfoMC& trkinfomc);
     void fillHitInfoMC(const KalSeedMC& kseedmc, TrkStrawHitInfoMC& tshinfomc, const TrkStrawHitMC& tshmc);
-    void fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo);
+    void fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo, GenInfo& gparentinfo);
     void fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep, std::vector<int> const& vids, double target_time);
 
     void fillHitInfoMCs(const KalSeedMC& kseedmc, std::vector<TrkStrawHitInfoMC>& tshinfomcs);

--- a/inc/InfoStructHelper.hh
+++ b/inc/InfoStructHelper.hh
@@ -46,7 +46,7 @@ namespace mu2e {
     void fillHitCount(RecoCount const& nrec, HitCount& hitcount);
 
     void fillTrkInfo(const KalSeed& kseed,TrkInfo& trkinfo);
-    void fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVec& pos);
+    void fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVectorF& pos);
     void fillTrkInfoHits(const KalSeed& kseed,TrkInfo& trkinfo);
     void fillTrkInfoStraws(const KalSeed& kseed,TrkInfo& trkinfo);
 

--- a/inc/Names.hh
+++ b/inc/Names.hh
@@ -1,0 +1,7 @@
+#ifndef TrkAna_Names_HH
+#define TrkAna_Names_HH
+#include <string>
+namespace Names {
+  std::string XYZnames(const char* vname);
+}
+#endif

--- a/inc/SimInfo.hh
+++ b/inc/SimInfo.hh
@@ -1,26 +1,26 @@
 //
-// structs used to record GenParticle information in TTrees.
+// structs used to record SimParticle information in TTrees.
 // All momenta are in units of MeV/c, time in nsec WRT when the proton bunch pulse peak hits the production target,
 // positions are in mm WRT the center of the tracker.
 // Andy Edmonds (March 2019)
-// 
-#ifndef GenInfo_HH
-#define GenInfo_HH
+//
+#ifndef SimInfo_HH
+#define SimInfo_HH
 #include "Offline/DataProducts/inc/GenVector.hh"
 #include "TrkAna/inc/helixpar.hh"
 #include "TrkAna/inc/Names.hh"
 #include "Rtypes.h"
 namespace mu2e
 {
-// general info about the gen particle which was simulated
-  struct GenInfo {
+// general info about the SimParticle which was simulated
+  struct SimInfo {
     Int_t _pdg, _gen; // true PDG code, generator code
     Float_t _time;  // time of this step
     Float_t _mom; // scalar momentum at the start of this step
     Float_t _costh; // cos(theta), where theta is angle between particle's momentum and z-axis
     Float_t _phi;   // azimuthal angle of particle's momentum vector
     XYZVectorF _pos;  // particle position at the start of this step
-    GenInfo() { reset(); }
+    SimInfo() { reset(); }
     void reset() { _pdg = _gen = -1; _time = -1.0; _mom = 0; _costh = 0; _phi = 0; _pos = XYZVectorF(); }
     static std::string leafnames() { static std::string leaves;
       leaves = std::string("pdg/I:gen/I:t0/F:mom/F:costh/F:phi/F:") + Names::XYZnames("pos");

--- a/inc/TrkCaloHitInfo.hh
+++ b/inc/TrkCaloHitInfo.hh
@@ -5,14 +5,14 @@
 #ifndef TrkCaloHitInfo_HH
 #define TrkCaloHitInfo_HH
 #include "Rtypes.h"
-#include "DataProducts/inc/XYZVec.hh"
+#include "DataProducts/inc/GenVector.hh"
 namespace mu2e 
 {
   struct TrkCaloHitInfo {
     Int_t _active;   // is this hit used in the track?
     Int_t _did; // disk ID
-    XYZVec _poca; // Position of Point Of Closest Approach (POCA)
-    XYZVec _mom; // Track momentum vector at Point Of Closest Approach (POCA)
+    XYZVectorF _poca; // Position of Point Of Closest Approach (POCA)
+    XYZVectorF _mom; // Track momentum vector at Point Of Closest Approach (POCA)
     Float_t _trklen;	// distance along the helix of the POCA for this hit
     Float_t _clen;    // length along the crystal from the front face
     Float_t _doca;	// DOCA of this hit

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -6,9 +6,10 @@
 //
 #ifndef TrkInfo_HH
 #define TrkInfo_HH
-#include "Offline/DataProducts/inc/XYZVec.hh"
+#include "Offline/DataProducts/inc/GenVector.hh"
 #include "TrkAna/inc/helixpar.hh"
 #include "Offline/MCDataProducts/inc/MCRelationship.hh"
+#include "TrkAna/inc/Names.hh"
 #include "Rtypes.h"
 namespace mu2e
 {
@@ -69,7 +70,7 @@ namespace mu2e
     Int_t _nambig; // number of true hits where the reconstruction assigned the correct left-right ambiguity
     Int_t _pdg, _gen, _proc; // true PDG code, generator code, and process code of the primary particle
     Float_t _otime;  // origin time
-    XYZVec _opos;  // origin position
+    XYZVectorF _opos;  // origin position
     Float_t _omom;   // origin momentum (scalar)
     Float_t _ocosth; // origin cos(theta), where theta is the angle between the particle's momentum and z-axis
     Float_t _ophi; // origin phi (azimuthal angle of particle's momentum vector)
@@ -78,12 +79,12 @@ namespace mu2e
     TrkInfoMC() { reset(); }
     void reset() { _ndigi = _ndigigood = _nactive = _nhits = _nambig = _pdg = _gen  = _proc= -1;  _otime=0.0;
       _prel = MCRelationship();
-      _opos = XYZVec();
+      _opos = XYZVectorF();
       _omom = -1, _ocosth = -1, _ophi=-1;
     }
     static std::string leafnames() { static std::string leaves; leaves =
       std::string("ndigi/I:ndigigood/I:nhits/I:nactive/I:nambig/I:pdg/I:gen/I:proc/I:otime/F:")
-    + Geom::XYZnames("opos") + std::string(":omom/F:ocosth/F:ophi/F:prel/B:prem/B");
+    + Names::XYZnames("opos") + std::string(":omom/F:ocosth/F:ophi/F:prel/B:prem/B");
 
       return leaves;
     }
@@ -94,12 +95,12 @@ namespace mu2e
     Float_t _mom; // scalar momentum of particle at the start of this step
     Float_t _costh; // cos(theta) of momentum vector of particles at the start of this step (theta is angle between momentum vector and z-axis)
     Float_t _phi; // azimuthal angle of momentum vector
-    XYZVec _pos;  // particle position at the start of this step
+    XYZVectorF _pos;  // particle position at the start of this step
     helixpar _hpar; // helix parameters corresponding to the particle position and momentum assuming the nominal BField
     TrkInfoMCStep() { reset(); }
-    void reset() { _time = -1; _mom = -1; _costh = -1; _phi = -1; _pos = XYZVec(); _hpar.reset(); }
+    void reset() { _time = -1; _mom = -1; _costh = -1; _phi = -1; _pos = XYZVectorF(); _hpar.reset(); }
     static std::string leafnames() { static std::string leaves; leaves =
-      std::string("t0/F:mom/F:costh/F:phi/F:") + Geom::XYZnames("pos") + std::string(":")+helixpar::leafnames();
+      std::string("t0/F:mom/F:costh/F:phi/F:") + Names::XYZnames("pos") + std::string(":")+helixpar::leafnames();
       return leaves;
     }
   };

--- a/inc/TrkStrawHitInfo.hh
+++ b/inc/TrkStrawHitInfo.hh
@@ -4,7 +4,7 @@
 #ifndef TrkStrawHitInfo_HH
 #define TrkStrawHitInfo_HH
 #include "Rtypes.h"
-#include "DataProducts/inc/XYZVec.hh"
+#include "DataProducts/inc/GenVector.hh"
 namespace mu2e 
 {
   struct TrkStrawHitInfo {
@@ -15,7 +15,7 @@ namespace mu2e
     Int_t _ambig;     // left-right amibiguity.  This signes the angular momentum of the track WRT the wire
     Int_t _driftend; // which end(s) was used in computing the drift
     Float_t _tdrift; // drift time
-    XYZVec _poca; // Position of Point Of Closest Approach (POCA)
+    XYZVectorF _poca; // Position of Point Of Closest Approach (POCA)
     Float_t _resid;	  // residual = Distance Of Closest Approach (DOCA) between the drift cylinder and the track, signed by the track angular momentum WRT the wire
     Float_t _residerr;	  // error on the residual, including components from the hit, the track, and potentially other effects 
     Float_t _rdrift, _rdrifterr;	  // drift radius and error of this hit

--- a/inc/TrkStrawHitInfoMC.hh
+++ b/inc/TrkStrawHitInfoMC.hh
@@ -4,7 +4,7 @@
 #ifndef TrkStrawHitInfoMC_HH
 #define TrkStrawHitInfoMC_HH
 #include "Rtypes.h"
-#include "DataProducts/inc/XYZVec.hh"
+#include "DataProducts/inc/GenVector.hh"
 #include "MCDataProducts/inc/MCRelationship.hh"
 namespace mu2e 
 {
@@ -18,7 +18,7 @@ namespace mu2e
     Float_t _edep;  // true energy deposit sum by trigger particles in the straw gas
     Float_t _mom;   // true particle momentum at the POCA
     Float_t _twdot; // dot product between track and wire directions
-    XYZVec _cpos; // threshold cluster position 
+    XYZVectorF _cpos; // threshold cluster position 
     Int_t _ambig;   // true left-right ambiguity = true angular momentum sign of the particle WRT the wire
     TrkStrawHitInfoMC() : _pdg(-1), _gen(-1), _proc(-1),
     _t0(-1000.0),  _dist(-1000.0), _doca(-1000.0), _len(-1000.0),

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -103,15 +103,23 @@ namespace mu2e {
     tshinfomc._doca = pca.dca();
   }
 
-  void InfoMCStructHelper::fillSimAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, SimInfo& priinfo, SimInfo& siminfo, SimInfo& parentinfo, SimInfo& gparentinfo) {
+  void InfoMCStructHelper::fillAllSimInfos(const KalSeedMC& kseedmc, std::vector<SimInfo>& siminfos, int n_generations) {
+    auto trkprimary = kseedmc.simParticle().simParticle(_spcH)->originParticle();
+
+    for (int i_generation = 0; i_generation < n_generations; ++i_generation) {
+      fillSimInfo(trkprimary, siminfos.at(i_generation));
+      if (trkprimary.parent().isNonnull()) {
+        trkprimary = trkprimary.parent()->originParticle();
+      }
+      else {
+        break; // this particle doesn't have a parent
+      }
+    }
+  }
+
+  void InfoMCStructHelper::fillPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, SimInfo& priinfo) {
     auto trkprimary = kseedmc.simParticle().simParticle(_spcH);
 
-    if (trkprimary->parent().isNonnull()) {
-      fillSimInfo(trkprimary->parent()->originParticle(), parentinfo);
-    }
-    if (trkprimary->parent()->originParticle().parent().isNonnull()) {
-      fillSimInfo(trkprimary->parent()->originParticle().parent()->originParticle(), gparentinfo);
-    }
     // go through the SimParticles of this primary, and find the one most related to the
     // downstream fit (KalSeedMC)
 
@@ -128,7 +136,6 @@ namespace mu2e {
       }
     } // redundant: FIXME!
     fillSimInfo(bestprimarysp, priinfo);
-    fillSimInfo(bestprimarysp, siminfo);
   }
 
   

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -39,7 +39,7 @@ namespace mu2e {
     // fill the origin information of this SimParticle
     GeomHandle<DetectorSystem> det;
     trkinfomc._otime = trkprimary->startGlobalTime() + _toff.totalTimeOffset(trkprimary);
-    trkinfomc._opos = Geom::toXYZVec(det->toDetector(trkprimary->startPosition()));
+    trkinfomc._opos = XYZVectorF(det->toDetector(trkprimary->startPosition()));
     trkinfomc._omom = trkprimary->startMomentum().vect().mag();
     trkinfomc._ocosth = std::cos(trkprimary->startMomentum().vect().theta());
     trkinfomc._ophi = trkprimary->startMomentum().vect().phi();
@@ -90,16 +90,16 @@ namespace mu2e {
 	
     // find the step midpoint
     const Straw& straw = tracker.getStraw(tshmc._strawId);
-    CLHEP::Hep3Vector mcsep = Geom::Hep3Vec(tshmc._cpos)-straw.getMidPoint();
+    CLHEP::Hep3Vector mcsep = GenVector::Hep3Vec(tshmc._cpos)-straw.getMidPoint();
     tshinfomc._len = mcsep.dot(straw.getDirection());
-    CLHEP::Hep3Vector mdir = Geom::Hep3Vec(tshmc._mom.unit());
+    CLHEP::Hep3Vector mdir = GenVector::Hep3Vec(tshmc._mom.unit());
     CLHEP::Hep3Vector mcperp = (mdir.cross(straw.getDirection())).unit();
     double dperp = mcperp.dot(mcsep);
     tshinfomc._twdot = mdir.dot(straw.getDirection());
     tshinfomc._dist = fabs(dperp);
     tshinfomc._ambig = dperp > 0 ? -1 : 1; // follow TrkPoca convention
     // use 2-line POCA here
-    TwoLinePCA pca(Geom::Hep3Vec(tshmc._cpos),mdir,straw.getMidPoint(),straw.getDirection());
+    TwoLinePCA pca(GenVector::Hep3Vec(tshmc._cpos),mdir,straw.getMidPoint(),straw.getDirection());
     tshinfomc._doca = pca.dca();
   }
 
@@ -135,7 +135,7 @@ namespace mu2e {
       geninfo._mom = gp->startMomentum().vect().mag();
       geninfo._costh = std::cos(gp->startMomentum().vect().theta());
       geninfo._phi = gp->startMomentum().vect().phi();
-      geninfo._pos = Geom::toXYZVec(det->toDetector(gp->startPosition()));
+      geninfo._pos = XYZVectorF(det->toDetector(gp->startPosition()));
       geninfo._time = gp->startGlobalTime(); 
     }
   }
@@ -163,12 +163,12 @@ namespace mu2e {
 	    trkinfomcstep._mom = std::sqrt(i_mcstep._mom.mag2());
 	    trkinfomcstep._costh = std::cos(i_mcstep._mom.theta());
 	    trkinfomcstep._phi = i_mcstep._mom.phi();
-	    trkinfomcstep._pos = Geom::Hep3Vec(i_mcstep._pos);
+	    trkinfomcstep._pos = GenVector::Hep3Vec(i_mcstep._pos);
 
 	    CLHEP::HepVector parvec(5,0);
 	    double hflt(0.0);
 	    HepPoint ppos(trkinfomcstep._pos.x(), trkinfomcstep._pos.y(), trkinfomcstep._pos.z());
-	    CLHEP::Hep3Vector mom = Geom::Hep3Vec(i_mcstep._mom);
+	    CLHEP::Hep3Vector mom = GenVector::Hep3Vec(i_mcstep._mom);
 	    double charge = pdt->particle(kseedmc.simParticle()._pdg).ref().charge();
 	    TrkHelixUtils::helixFromMom( parvec, hflt,ppos, mom,charge,bz);
 	    trkinfomcstep._hpar = helixpar(parvec);

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -103,14 +103,14 @@ namespace mu2e {
     tshinfomc._doca = pca.dca();
   }
 
-  void InfoMCStructHelper::fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo, GenInfo& gparentinfo) {
+  void InfoMCStructHelper::fillSimAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, SimInfo& priinfo, SimInfo& siminfo, SimInfo& parentinfo, SimInfo& gparentinfo) {
     auto trkprimary = kseedmc.simParticle().simParticle(_spcH);
 
     if (trkprimary->parent().isNonnull()) {
-      fillGenInfo(trkprimary->parent()->originParticle(), parentinfo);
+      fillSimInfo(trkprimary->parent()->originParticle(), parentinfo);
     }
     if (trkprimary->parent()->originParticle().parent().isNonnull()) {
-      fillGenInfo(trkprimary->parent()->originParticle().parent()->originParticle(), gparentinfo);
+      fillSimInfo(trkprimary->parent()->originParticle().parent()->originParticle(), gparentinfo);
     }
     // go through the SimParticles of this primary, and find the one most related to the
     // downstream fit (KalSeedMC)
@@ -127,28 +127,28 @@ namespace mu2e {
 	bestprimarysp = spp;
       }
     } // redundant: FIXME!
-    fillGenInfo(bestprimarysp, priinfo);
-    fillGenInfo(bestprimarysp, geninfo);
+    fillSimInfo(bestprimarysp, priinfo);
+    fillSimInfo(bestprimarysp, siminfo);
   }
 
   
-  void InfoMCStructHelper::fillGenInfo(const art::Ptr<SimParticle>& gp, GenInfo& geninfo) {
-    if(gp.isNonnull()){
-      fillGenInfo(*gp, geninfo);
+  void InfoMCStructHelper::fillSimInfo(const art::Ptr<SimParticle>& sp, SimInfo& siminfo) {
+    if(sp.isNonnull()){
+      fillSimInfo(*sp, siminfo);
     }
   }
 
-  void InfoMCStructHelper::fillGenInfo(const SimParticle& gp, GenInfo& geninfo) {
+  void InfoMCStructHelper::fillSimInfo(const SimParticle& sp, SimInfo& siminfo) {
 
     GeomHandle<DetectorSystem> det;
 
-    geninfo._pdg = gp.pdgId();
-    geninfo._gen = gp.creationCode();
-    geninfo._mom = gp.startMomentum().vect().mag();
-    geninfo._costh = std::cos(gp.startMomentum().vect().theta());
-    geninfo._phi = gp.startMomentum().vect().phi();
-    geninfo._pos = XYZVectorF(det->toDetector(gp.startPosition()));
-    geninfo._time = gp.startGlobalTime();
+    siminfo._pdg = sp.pdgId();
+    siminfo._gen = sp.creationCode();
+    siminfo._mom = sp.startMomentum().vect().mag();
+    siminfo._costh = std::cos(sp.startMomentum().vect().theta());
+    siminfo._phi = sp.startMomentum().vect().phi();
+    siminfo._pos = XYZVectorF(det->toDetector(sp.startPosition()));
+    siminfo._time = sp.startGlobalTime();
   }
 
   void InfoMCStructHelper::fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep,

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -142,18 +142,17 @@ namespace mu2e {
 
     GeomHandle<DetectorSystem> det;
 
-    if(gp.isNonnull()){
-      geninfo._pdg = gp->pdgId();
-      geninfo._gen = gp->creationCode();
-      geninfo._mom = gp->startMomentum().vect().mag();
-      geninfo._costh = std::cos(gp->startMomentum().vect().theta());
-      geninfo._phi = gp->startMomentum().vect().phi();
-      geninfo._pos = XYZVectorF(det->toDetector(gp->startPosition()));
-      geninfo._time = gp->startGlobalTime();
-    }
+    geninfo._pdg = gp.pdgId();
+    geninfo._gen = gp.creationCode();
+    geninfo._mom = gp.startMomentum().vect().mag();
+    geninfo._costh = std::cos(gp.startMomentum().vect().theta());
+    geninfo._phi = gp.startMomentum().vect().phi();
+    geninfo._pos = XYZVectorF(det->toDetector(gp.startPosition()));
+    geninfo._time = gp.startGlobalTime();
+  }
 
-    void InfoMCStructHelper::fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep,
-                                               std::vector<int> const& vids, double target_time) {
+  void InfoMCStructHelper::fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep,
+                                             std::vector<int> const& vids, double target_time) {
 
     GeomHandle<BFieldManager> bfmgr;
     GeomHandle<DetectorSystem> det;

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -106,8 +106,12 @@ namespace mu2e {
   void InfoMCStructHelper::fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo, GenInfo& gparentinfo) {
     auto trkprimary = kseedmc.simParticle().simParticle(_spcH);
 
-    fillGenInfo(trkprimary->parent()->originParticle(), parentinfo);
-    fillGenInfo(trkprimary->parent()->originParticle().parent()->originParticle(), gparentinfo);
+    if (trkprimary->parent().isNonnull()) {
+      fillGenInfo(trkprimary->parent()->originParticle(), parentinfo);
+    }
+    if (trkprimary->parent()->originParticle().parent().isNonnull()) {
+      fillGenInfo(trkprimary->parent()->originParticle().parent()->originParticle(), gparentinfo);
+    }
     // go through the SimParticles of this primary, and find the one most related to the
     // downstream fit (KalSeedMC)
 

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -103,9 +103,10 @@ namespace mu2e {
     tshinfomc._doca = pca.dca();
   }
 
-  void InfoMCStructHelper::fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo) {
+  void InfoMCStructHelper::fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo) {
     auto trkprimary = kseedmc.simParticle().simParticle(_spcH);
 
+    fillGenInfo(trkprimary->parent(), parentinfo);
     // go through the SimParticles of this primary, and find the one most related to the
     // downstream fit (KalSeedMC)
 

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -103,10 +103,11 @@ namespace mu2e {
     tshinfomc._doca = pca.dca();
   }
 
-  void InfoMCStructHelper::fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo) {
+  void InfoMCStructHelper::fillGenAndPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, GenInfo& priinfo, GenInfo& geninfo, GenInfo& parentinfo, GenInfo& gparentinfo) {
     auto trkprimary = kseedmc.simParticle().simParticle(_spcH);
 
-    fillGenInfo(trkprimary->parent(), parentinfo);
+    fillGenInfo(trkprimary->parent()->originParticle(), parentinfo);
+    fillGenInfo(trkprimary->parent()->originParticle().parent()->originParticle(), gparentinfo);
     // go through the SimParticles of this primary, and find the one most related to the
     // downstream fit (KalSeedMC)
 
@@ -126,7 +127,14 @@ namespace mu2e {
     fillGenInfo(bestprimarysp, geninfo);
   }
 
+  
   void InfoMCStructHelper::fillGenInfo(const art::Ptr<SimParticle>& gp, GenInfo& geninfo) {
+    if(gp.isNonnull()){
+      fillGenInfo(*gp, geninfo);
+    }
+  }
+
+  void InfoMCStructHelper::fillGenInfo(const SimParticle& gp, GenInfo& geninfo) {
 
     GeomHandle<DetectorSystem> det;
 
@@ -137,12 +145,11 @@ namespace mu2e {
       geninfo._costh = std::cos(gp->startMomentum().vect().theta());
       geninfo._phi = gp->startMomentum().vect().phi();
       geninfo._pos = XYZVectorF(det->toDetector(gp->startPosition()));
-      geninfo._time = gp->startGlobalTime(); 
+      geninfo._time = gp->startGlobalTime();
     }
-  }
 
-  void InfoMCStructHelper::fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep,
-					     std::vector<int> const& vids, double target_time) {
+    void InfoMCStructHelper::fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep,
+                                               std::vector<int> const& vids, double target_time) {
 
     GeomHandle<BFieldManager> bfmgr;
     GeomHandle<DetectorSystem> det;

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -86,7 +86,7 @@ namespace mu2e {
     fillTrkInfoStraws(kseed, trkinfo);
   }
 
-  void InfoStructHelper::fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVec& pos) {
+  void InfoStructHelper::fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVectorF& pos) {
     const auto& ksegIter = kseed.nearestSegment(pos);
     if (ksegIter == kseed.segments().end()) {
       cet::exception("InfoStructHelper") << "Couldn't find KalSegment that includes pos = " << pos;
@@ -154,9 +154,9 @@ namespace mu2e {
       // find nearest segment
       auto ikseg = kseed.nearestSegment(ihit->trkLen());
       if(ikseg != kseed.segments().end()){
-	XYZVec dir;
+	XYZVectorF dir;
 	ikseg->helix().direction(ikseg->localFlt(ihit->trkLen()),dir);
-	auto tdir = Geom::Hep3Vec(dir);
+	auto tdir = GenVector::Hep3Vec(dir);
 	tshinfo._wdot = tdir.dot(straw.getDirection());
       }
       tshinfo._residerr = ihit->radialErr();
@@ -183,7 +183,7 @@ namespace mu2e {
       auto const& wiredir = straw.getDirection();
       auto const& mid = straw.getMidPoint();
       CLHEP::Hep3Vector hpos = mid + wiredir*ihit->hitLen();
-      tshinfo._poca = Geom::toXYZVec(hpos);
+      tshinfo._poca = XYZVectorF(hpos);
 
       // count correlations with other TSH
       for(std::vector<TrkStrawHitSeed>::const_iterator jhit=kseed.hits().begin(); jhit != ihit; ++jhit) {
@@ -248,7 +248,7 @@ namespace mu2e {
       // transform cog to tracker coordinates; requires 2 steps.  This is at the front
       // of the disk
       mu2e::GeomHandle<mu2e::Calorimeter> calo;
-      XYZVec cpos = Geom::toXYZVec(calo->geomUtil().mu2eToTracker(calo->geomUtil().diskToMu2e(cc->diskID(),cc->cog3Vector())));
+      XYZVectorF cpos = XYZVectorF(calo->geomUtil().mu2eToTracker(calo->geomUtil().diskToMu2e(cc->diskID(),cc->cog3Vector())));
       // move to the front face and 
       // add the cluster length (relative to the front face).  crystal size should come from geom FIXME!
       cpos.SetZ(cpos.z() -200.0 + tch.hitLen());
@@ -314,7 +314,7 @@ namespace mu2e {
       auto ffpos = calo->geomUtil().mu2eToTracker(calo->geomUtil().diskFFToMu2e(idisk,origin));
       float flen = trkhel.zFlight(ffpos.z());
       float blen = trkhel.zFlight(ffpos.z()+207.5); // private communication B. Echenard FIXME!!!!
-      XYZVec extpos;
+      XYZVectorF extpos;
       trkhel.position(flen,extpos);
       trkpidInfo._diskfrad[idisk] = sqrt(extpos.Perp2());	
       trkhel.position(blen,extpos);

--- a/src/Names.cc
+++ b/src/Names.cc
@@ -1,0 +1,10 @@
+#include "TrkAna/inc/Names.hh"
+namespace Names {
+  std::string XYZnames(const char* vname) {
+    std::string svname(vname);
+    static std::string leaves; leaves = svname + std::string("x/F:") +
+      svname + std::string("y/F:") + svname + std::string("z/F");
+    return leaves;
+  }
+}
+

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -208,6 +208,7 @@ namespace mu2e {
     std::vector<int> _entvids, _midvids, _xitvids;
     // MC truth branches (outputs)
     std::vector<TrkInfoMC> _allMCTIs;
+    std::vector<GenInfo> _allMCParentTIs;
     std::vector<GenInfo> _allMCGenTIs, _allMCPriTIs;
     std::vector<TrkInfoMCStep> _allMCEntTIs, _allMCMidTIs, _allMCXitTIs;
     std::vector<CaloClusterInfoMC> _allMCTCHIs;
@@ -286,9 +287,10 @@ namespace mu2e {
 
       TrkInfoMC mcti;
       _allMCTIs.push_back(mcti);
-      GenInfo mcgen, mcpri;
+      GenInfo mcgen, mcpri, mcparent;
       _allMCGenTIs.push_back(mcgen);
       _allMCPriTIs.push_back(mcpri);
+      _allMCParentTIs.push_back(mcparent);
       TrkInfoMCStep mcent, mcmid, mcxit;
       _allMCEntTIs.push_back(mcent);
       _allMCMidTIs.push_back(mcmid);
@@ -353,6 +355,7 @@ namespace mu2e {
       // optionall add MC branches
       if(_conf.fillmc() && i_branchConfig.options().fillmc()){
         _trkana->Branch((branch+"mc").c_str(),&_allMCTIs.at(i_branch),TrkInfoMC::leafnames().c_str());
+        _trkana->Branch((branch+"mcparent").c_str(),&_allMCParentTIs.at(i_branch),GenInfo::leafnames().c_str());
         _trkana->Branch((branch+"mcgen").c_str(),&_allMCGenTIs.at(i_branch),GenInfo::leafnames().c_str());
         _trkana->Branch((branch+"mcpri").c_str(),&_allMCPriTIs.at(i_branch),GenInfo::leafnames().c_str());
         _trkana->Branch((branch+"mcent").c_str(),&_allMCEntTIs.at(i_branch),TrkInfoMCStep::leafnames().c_str());
@@ -749,7 +752,7 @@ namespace mu2e {
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCEntTIs.at(i_branch), _entvids, t0);
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCMidTIs.at(i_branch), _midvids, t0);
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCXitTIs.at(i_branch), _xitvids, t0);
-          _infoMCStructHelper.fillGenAndPriInfo(kseedmc, primary, _allMCPriTIs.at(i_branch), _allMCGenTIs.at(i_branch));
+          _infoMCStructHelper.fillGenAndPriInfo(kseedmc, primary, _allMCPriTIs.at(i_branch), _allMCGenTIs.at(i_branch), _allMCParentTIs.at(i_branch));
 
           if(_conf.diag() > 1 || (_conf.fillhits() && branchConfig.options().fillhits())){
             _infoMCStructHelper.fillHitInfoMCs(kseedmc, _allTSHIMCs.at(i_branch));

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -61,7 +61,7 @@
 #include "TrkAna/inc/TrkCount.hh"
 #include "TrkAna/inc/EventInfo.hh"
 #include "TrkAna/inc/TrkInfo.hh"
-#include "TrkAna/inc/GenInfo.hh"
+#include "TrkAna/inc/SimInfo.hh"
 #include "TrkAna/inc/EventWeightInfo.hh"
 #include "TrkAna/inc/TrkStrawHitInfo.hh"
 #include "TrkAna/inc/TrkStrawHitInfoMC.hh"
@@ -208,8 +208,8 @@ namespace mu2e {
     std::vector<int> _entvids, _midvids, _xitvids;
     // MC truth branches (outputs)
     std::vector<TrkInfoMC> _allMCTIs;
-    std::vector<GenInfo> _allMCParentTIs, _allMCGParentTIs;
-    std::vector<GenInfo> _allMCGenTIs, _allMCPriTIs;
+    std::vector<SimInfo> _allMCParentTIs, _allMCGParentTIs;
+    std::vector<SimInfo> _allMCSimTIs, _allMCPriTIs;
     std::vector<TrkInfoMCStep> _allMCEntTIs, _allMCMidTIs, _allMCXitTIs;
     std::vector<CaloClusterInfoMC> _allMCTCHIs;
 
@@ -287,8 +287,8 @@ namespace mu2e {
 
       TrkInfoMC mcti;
       _allMCTIs.push_back(mcti);
-      GenInfo mcgen, mcpri, mcparent, mcgparent;
-      _allMCGenTIs.push_back(mcgen);
+      SimInfo mcsim, mcpri, mcparent, mcgparent;
+      _allMCSimTIs.push_back(mcsim);
       _allMCPriTIs.push_back(mcpri);
       _allMCParentTIs.push_back(mcparent);
       _allMCGParentTIs.push_back(mcgparent);
@@ -356,10 +356,10 @@ namespace mu2e {
       // optionall add MC branches
       if(_conf.fillmc() && i_branchConfig.options().fillmc()){
         _trkana->Branch((branch+"mc").c_str(),&_allMCTIs.at(i_branch),TrkInfoMC::leafnames().c_str());
-        _trkana->Branch((branch+"mcparent").c_str(),&_allMCParentTIs.at(i_branch),GenInfo::leafnames().c_str());
-        _trkana->Branch((branch+"mcgparent").c_str(),&_allMCGParentTIs.at(i_branch),GenInfo::leafnames().c_str());
-        _trkana->Branch((branch+"mcgen").c_str(),&_allMCGenTIs.at(i_branch),GenInfo::leafnames().c_str());
-        _trkana->Branch((branch+"mcpri").c_str(),&_allMCPriTIs.at(i_branch),GenInfo::leafnames().c_str());
+        _trkana->Branch((branch+"mcparent").c_str(),&_allMCParentTIs.at(i_branch),SimInfo::leafnames().c_str());
+        _trkana->Branch((branch+"mcgparent").c_str(),&_allMCGParentTIs.at(i_branch),SimInfo::leafnames().c_str());
+        _trkana->Branch((branch+"mcsim").c_str(),&_allMCSimTIs.at(i_branch),SimInfo::leafnames().c_str());
+        _trkana->Branch((branch+"mcpri").c_str(),&_allMCPriTIs.at(i_branch),SimInfo::leafnames().c_str());
         _trkana->Branch((branch+"mcent").c_str(),&_allMCEntTIs.at(i_branch),TrkInfoMCStep::leafnames().c_str());
         _trkana->Branch((branch+"mcmid").c_str(),&_allMCMidTIs.at(i_branch),TrkInfoMCStep::leafnames().c_str());
         _trkana->Branch((branch+"mcxit").c_str(),&_allMCXitTIs.at(i_branch),TrkInfoMCStep::leafnames().c_str());
@@ -754,7 +754,7 @@ namespace mu2e {
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCEntTIs.at(i_branch), _entvids, t0);
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCMidTIs.at(i_branch), _midvids, t0);
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCXitTIs.at(i_branch), _xitvids, t0);
-          _infoMCStructHelper.fillGenAndPriInfo(kseedmc, primary, _allMCPriTIs.at(i_branch), _allMCGenTIs.at(i_branch), _allMCParentTIs.at(i_branch), _allMCGParentTIs.at(i_branch));
+          _infoMCStructHelper.fillSimAndPriInfo(kseedmc, primary, _allMCPriTIs.at(i_branch), _allMCSimTIs.at(i_branch), _allMCParentTIs.at(i_branch), _allMCGParentTIs.at(i_branch));
 
           if(_conf.diag() > 1 || (_conf.fillhits() && branchConfig.options().fillhits())){
             _infoMCStructHelper.fillHitInfoMCs(kseedmc, _allTSHIMCs.at(i_branch));
@@ -825,7 +825,7 @@ namespace mu2e {
       _allTCHIs.at(i_branch).reset();
 
       _allMCTIs.at(i_branch).reset();
-      _allMCGenTIs.at(i_branch).reset();
+      _allMCSimTIs.at(i_branch).reset();
       _allMCPriTIs.at(i_branch).reset();
 
       _allMCEntTIs.at(i_branch).reset();

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -677,9 +677,9 @@ namespace mu2e {
     // get VD positions
     mu2e::GeomHandle<VirtualDetector> vdHandle;
     mu2e::GeomHandle<DetectorSystem> det;
-    const XYZVec& entpos = XYZVec(det->toDetector(vdHandle->getGlobal(*_entvids.begin())));
-    const XYZVec& midpos = XYZVec(det->toDetector(vdHandle->getGlobal(*_midvids.begin())));
-    const XYZVec& xitpos = XYZVec(det->toDetector(vdHandle->getGlobal(*_xitvids.begin())));
+    const XYZVectorF& entpos = XYZVectorF(det->toDetector(vdHandle->getGlobal(*_entvids.begin())));
+    const XYZVectorF& midpos = XYZVectorF(det->toDetector(vdHandle->getGlobal(*_midvids.begin())));
+    const XYZVectorF& xitpos = XYZVectorF(det->toDetector(vdHandle->getGlobal(*_xitvids.begin())));
 
     _infoStructHelper.fillTrkInfo(kseed,_allTIs.at(i_branch));
     _infoStructHelper.fillTrkFitInfo(kseed,_allEntTIs.at(i_branch),entpos);

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -769,7 +769,8 @@ namespace mu2e {
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCEntTIs.at(i_branch), _entvids, t0);
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCMidTIs.at(i_branch), _midvids, t0);
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCXitTIs.at(i_branch), _xitvids, t0);
-          _infoMCStructHelper.fillSimAndPriInfo(kseedmc, primary, _allMCPriTIs.at(i_branch), _allMCSimTIs.at(i_branch).at(0), _allMCSimTIs.at(i_branch).at(1), _allMCSimTIs.at(i_branch).at(2));
+          _infoMCStructHelper.fillPriInfo(kseedmc, primary, _allMCPriTIs.at(i_branch));
+          _infoMCStructHelper.fillAllSimInfos(kseedmc, _allMCSimTIs.at(i_branch), branchConfig.options().genealogyDepth());
 
           if(_conf.diag() > 1 || (_conf.fillhits() && branchConfig.options().fillhits())){
             _infoMCStructHelper.fillHitInfoMCs(kseedmc, _allTSHIMCs.at(i_branch));

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -208,7 +208,7 @@ namespace mu2e {
     std::vector<int> _entvids, _midvids, _xitvids;
     // MC truth branches (outputs)
     std::vector<TrkInfoMC> _allMCTIs;
-    std::vector<GenInfo> _allMCParentTIs;
+    std::vector<GenInfo> _allMCParentTIs, _allMCGParentTIs;
     std::vector<GenInfo> _allMCGenTIs, _allMCPriTIs;
     std::vector<TrkInfoMCStep> _allMCEntTIs, _allMCMidTIs, _allMCXitTIs;
     std::vector<CaloClusterInfoMC> _allMCTCHIs;
@@ -287,10 +287,11 @@ namespace mu2e {
 
       TrkInfoMC mcti;
       _allMCTIs.push_back(mcti);
-      GenInfo mcgen, mcpri, mcparent;
+      GenInfo mcgen, mcpri, mcparent, mcgparent;
       _allMCGenTIs.push_back(mcgen);
       _allMCPriTIs.push_back(mcpri);
       _allMCParentTIs.push_back(mcparent);
+      _allMCGParentTIs.push_back(mcgparent);
       TrkInfoMCStep mcent, mcmid, mcxit;
       _allMCEntTIs.push_back(mcent);
       _allMCMidTIs.push_back(mcmid);
@@ -356,6 +357,7 @@ namespace mu2e {
       if(_conf.fillmc() && i_branchConfig.options().fillmc()){
         _trkana->Branch((branch+"mc").c_str(),&_allMCTIs.at(i_branch),TrkInfoMC::leafnames().c_str());
         _trkana->Branch((branch+"mcparent").c_str(),&_allMCParentTIs.at(i_branch),GenInfo::leafnames().c_str());
+        _trkana->Branch((branch+"mcgparent").c_str(),&_allMCGParentTIs.at(i_branch),GenInfo::leafnames().c_str());
         _trkana->Branch((branch+"mcgen").c_str(),&_allMCGenTIs.at(i_branch),GenInfo::leafnames().c_str());
         _trkana->Branch((branch+"mcpri").c_str(),&_allMCPriTIs.at(i_branch),GenInfo::leafnames().c_str());
         _trkana->Branch((branch+"mcent").c_str(),&_allMCEntTIs.at(i_branch),TrkInfoMCStep::leafnames().c_str());
@@ -752,7 +754,7 @@ namespace mu2e {
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCEntTIs.at(i_branch), _entvids, t0);
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCMidTIs.at(i_branch), _midvids, t0);
           _infoMCStructHelper.fillTrkInfoMCStep(kseedmc, _allMCXitTIs.at(i_branch), _xitvids, t0);
-          _infoMCStructHelper.fillGenAndPriInfo(kseedmc, primary, _allMCPriTIs.at(i_branch), _allMCGenTIs.at(i_branch), _allMCParentTIs.at(i_branch));
+          _infoMCStructHelper.fillGenAndPriInfo(kseedmc, primary, _allMCPriTIs.at(i_branch), _allMCGenTIs.at(i_branch), _allMCParentTIs.at(i_branch), _allMCGParentTIs.at(i_branch));
 
           if(_conf.diag() > 1 || (_conf.fillhits() && branchConfig.options().fillhits())){
             _infoMCStructHelper.fillHitInfoMCs(kseedmc, _allTSHIMCs.at(i_branch));


### PR DESCRIPTION
I went a bit further with adding genealogy information than the original PR so here is an updated message:

In this PR I have added the ability to configure the depth of the MC genealogy that is stored in the trkana tree. The new branches are:
 - `demsim` : MC information for the particle that created the track
 - `demcparent`: MC information for the parent of the particle that created the track
  - `demcgparent`: MC information for the grandparent of the particle that created the track
  - `demcggparent`: MC information for the great-grandparent of the particle that created the track
  - additional levels insert an extra `g` in the branch name
 
This PR also remove the `demcgen` branch

The depth of the genealogy is set to 5 by default for the candidate branch (`de`). MC information for the supplemental branches (`ue`, `dm`) is not on by default. The depth can be changed with the fcl parameter:
```
physics.analyzers.TrkAnaNeg.candidate.options.genealogyDepth : 5
```
where depth = 2 stores the information of the particle that created the track and its parent.

Here is an example output for a CeEndpointMix dataset:

```
root [2] trkana->Scan("demcsim.pdg:demcparent.pdg:demcgparent.pdg:demcggparent.pdg:demcgggparent.pdg")
************************************************************************
*    Row   * demcsim.p * demcparen * demcgpare * demcggpar * demcgggpa *
************************************************************************
*        0 *        11 *        13 *      -211 *      3122 *      2212 *
*        1 *        11 *        13 *      -211 *      2212 *      2212 *
*        2 *        11 *        13 *      -211 *      2212 *        -1 *
*        3 *        11 *        13 *      -211 *      2212 *        -1 *
*        4 *        11 *        13 *      -211 *      2212 *        -1 *
*        5 *        11 *        13 *      -211 *      3122 *      2212 *
*        6 *        11 *        13 *      -211 *      3122 *      3212 *
*        7 *        11 *        13 *      -211 *      2212 *      2112 *
*        8 *        11 *        13 *      -211 *      2212 *      2212 *
*        9 *        11 *        13 *      -211 *      2212 *        -1 *
*       10 *        11 *        13 *      -211 *      2212 *        -1 *
*       11 *        11 *        13 *      -211 *      2212 *        -1 *
*       12 *        11 *        13 *      -211 *      2212 *        -1 *
*       13 *        11 *        13 *      -211 *      3122 *      2212 *
```

=============================
Original PR message;

In this PR, I have added the parent and grandparent information with new branches `demcparent` and `demcgparent`. This is just a quick solution so that people can start using it.

There will be some further development work to clean up the code, and I will think about the best way to implement going back an arbitrary number of generations. This will also include checks to make sure that the genealogy hasn't been compressed away. For the time being, going back 2 generations should be safe.
