### PR TITLE
Genealogy bugfix

### DIFF
--- a/inc/InfoStructHelper.hh
+++ b/inc/InfoStructHelper.hh
@@ -46,7 +46,7 @@ namespace mu2e {
     void fillHitCount(RecoCount const& nrec, HitCount& hitcount);
 
     void fillTrkInfo(const KalSeed& kseed,TrkInfo& trkinfo);
-    void fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, TrkFitInfoKK& trkfitinfokk, const XYZVectorF& pos);
+    void fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVectorF& pos);
     void fillTrkInfoHits(const KalSeed& kseed,TrkInfo& trkinfo);
     void fillTrkInfoStraws(const KalSeed& kseed,TrkInfo& trkinfo);
 

--- a/inc/InfoStructHelper.hh
+++ b/inc/InfoStructHelper.hh
@@ -46,7 +46,7 @@ namespace mu2e {
     void fillHitCount(RecoCount const& nrec, HitCount& hitcount);
 
     void fillTrkInfo(const KalSeed& kseed,TrkInfo& trkinfo);
-    void fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVectorF& pos);
+    void fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, TrkFitInfoKK& trkfitinfokk, const XYZVectorF& pos);
     void fillTrkInfoHits(const KalSeed& kseed,TrkInfo& trkinfo);
     void fillTrkInfoStraws(const KalSeed& kseed,TrkInfo& trkinfo);
 

--- a/inc/InfoStructHelper.hh
+++ b/inc/InfoStructHelper.hh
@@ -45,7 +45,7 @@ namespace mu2e {
     void fillHitCount(const StrawHitFlagCollection& flags, HitCount& hitcount);
     void fillHitCount(RecoCount const& nrec, HitCount& hitcount);
 
-    void fillTrkInfo(const KalSeed& kseed,TrkInfo& trkinfo);
+    void fillTrkInfo(const KalSeed& kseed,TrkInfo& trkinfo, const XYZVectorF& pos);
     void fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVectorF& pos);
     void fillTrkInfoHits(const KalSeed& kseed,TrkInfo& trkinfo);
     void fillTrkInfoStraws(const KalSeed& kseed,TrkInfo& trkinfo);

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -15,18 +15,6 @@ namespace mu2e
 {
 // information about the track fit at a particular place
   struct TrkFitInfo {
-    Float_t _fitmom,_fitmomerr;
-    helixpar _fitpar;
-    helixpar _fitparerr;
-    TrkFitInfo() { reset(); }
-    void reset() { _fitmom=_fitmomerr=-1000.0; _fitpar.reset(); _fitparerr.reset(); }
-    static std::string leafnames() { static std::string leaves; leaves =
-      std::string("mom/F:momerr/F:")+helixpar::leafnames()+std::string(":d0err/F:p0err/F:omerr/F:z0err/F:tderr/F");
-      return leaves;
-    }
-  };
-
-  struct TrkFitInfoKK {
     Float_t _mom, _momerr; // momentum and its uncertinaty [MeV/c]
     Float_t _minr; // minimum radius of the helix [mm]
     Float_t _maxr; // maximum radius of the helix [mm]
@@ -36,7 +24,7 @@ namespace mu2e
     Float_t _cx, _cxerr;
     Float_t _cy, _cyerr;
     Float_t _t0, _t0err;
-    TrkFitInfoKK() { reset(); }
+    TrkFitInfo() { reset(); }
     void reset() { _mom=_momerr=-1000.0; _minr=_maxr=_pitch=_rad=_raderr=_lam=_lamerr=_cx=_cxerr=_cy=_cyerr=_t0=_t0err=0; }
     static std::string leafnames() {
       static std::string leaves;

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -16,9 +16,6 @@ namespace mu2e
 // information about the track fit at a particular place
   struct TrkFitInfo {
     Float_t _mom, _momerr; // momentum and its uncertinaty [MeV/c]
-    Float_t _minr; // minimum radial position of the helix [mm]
-    Float_t _maxr; // maximum radial position of the helix [mm]
-    Float_t _pitch; // pitch angle [rad]
     Float_t _time; // time of helix at this segment [ns]
     Float_t _phi; // azimuthal angle of helix at this segment [rad]
 
@@ -30,10 +27,10 @@ namespace mu2e
     Float_t _phi0, _phi0err; // azimuthal angle of helix at z=0 [rad]
     Float_t _t0, _t0err; // time of helix at z=0 [ns]
     TrkFitInfo() { reset(); }
-    void reset() { _mom=_momerr=-1000.0; _minr=_maxr=_pitch=_time=_phi=_rad=_raderr=_lam=_lamerr=_cx=_cxerr=_cy=_cyerr=_phi0=_phi0err=_t0=_t0err=0; }
+    void reset() { _mom=_momerr=_time=_phi=-1000.0; _rad=_raderr=_lam=_lamerr=_cx=_cxerr=_cy=_cyerr=_phi0=_phi0err=_t0=_t0err=0; }
     static std::string leafnames() {
       static std::string leaves;
-      leaves = std::string("mom/F:momerr/F:minr/F:maxr/F:pitch/F:time/F:phi/F:rad/F:raderr/F:lam/F:lamerr/F:cx/F:cxerr/F:cy/F:cyerr/F:phi0/F:phi0err/F:t0/F:t0err/F");
+      leaves = std::string("mom/F:momerr/F:time/F:phi/F:rad/F:raderr/F:lam/F:lamerr/F:cx/F:cxerr/F:cy/F:cyerr/F:phi0/F:phi0err/F:t0/F:t0err/F");
       return leaves;
     }
   };
@@ -42,6 +39,13 @@ namespace mu2e
   struct TrkInfo {
     Int_t _status; // Kalman fit status
     Int_t _alg; // pat. rec. algorithm
+    Float_t _mom; // momentum of track [MeV/c] (at entrance)
+    Float_t _momerr; // error on momentum of track [MeV/c] (at entrance)
+    Float_t _minr; // minimum radial position of the helix [mm] (at entrance)
+    Float_t _maxr; // maximum radial position of the helix [mm] (at entrance)
+    Float_t _pitch; // pitch angle [rad] (at entrance)
+    Float_t _time; // time of helix at this segment [ns] (at entrance)
+    Float_t _phi; // azimuthal angle of helix at this segment [rad] (at entrance)
     Int_t _pdg;   // PDG code of particle assumed in fit
     Int_t _nhits;     // # hits associated to this track
     Int_t _ndof;      // number of degrees of freedom in the fit
@@ -60,6 +64,7 @@ namespace mu2e
     void reset() { 
       _status = -1000;
       _alg=0;
+      _mom = _momerr = _minr = _maxr = _pitch = _time = _phi = -1000.0;
       _pdg = 0;
       _nhits = _nactive = _ndouble = _ndactive = _nnullambig = _nmat = _nmatactive = _nseg = _ndof = -1;
       _chisq = _fitcon = _radlen = _firstflt = _lastflt = -1.0;
@@ -67,7 +72,7 @@ namespace mu2e
       _startvalid = _endvalid = -999999.0;
     }
     static std::string const& leafnames() { static const std::string leaves =
-    std::string("status/I:alg/I:pdg/I:nhits/I:ndof/I:nactive/I:ndouble/I:ndactive/I:nnullambig/I:nmat/I:nmatactive/I:nseg/I:chisq/F:fitcon/F:radlen/F:firstflt/F:lastflt/F:startvalid/F:endvalid/F");
+    std::string("status/I:alg/I:mom/F:momerr/F:minr/F:maxr/F:pitch/F:time/F:phi/F:pdg/I:nhits/I:ndof/I:nactive/I:ndouble/I:ndactive/I:nnullambig/I:nmat/I:nmatactive/I:nseg/I:chisq/F:fitcon/F:radlen/F:firstflt/F:lastflt/F:startvalid/F:endvalid/F");
      return leaves;
     }
   };

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -16,20 +16,24 @@ namespace mu2e
 // information about the track fit at a particular place
   struct TrkFitInfo {
     Float_t _mom, _momerr; // momentum and its uncertinaty [MeV/c]
-    Float_t _minr; // minimum radius of the helix [mm]
-    Float_t _maxr; // maximum radius of the helix [mm]
+    Float_t _minr; // minimum radial position of the helix [mm]
+    Float_t _maxr; // maximum radial position of the helix [mm]
     Float_t _pitch; // pitch angle [rad]
-    Float_t _rad, _raderr;
-    Float_t _lam, _lamerr;
-    Float_t _cx, _cxerr;
-    Float_t _cy, _cyerr;
-    Float_t _phi0, _phi0err;
-    Float_t _t0, _t0err;
+    Float_t _time; // time of helix at this segment [ns]
+    Float_t _phi; // azimuthal angle of helix at this segment [rad]
+
+    // LoopHelix parameters
+    Float_t _rad, _raderr; // radius of helix [mm]
+    Float_t _lam, _lamerr; // longitudinal wavelength of helix [mm]
+    Float_t _cx, _cxerr; // x-position of helix center [mm]
+    Float_t _cy, _cyerr; // y-position of helix center [mm]
+    Float_t _phi0, _phi0err; // azimuthal angle of helix at z=0 [rad]
+    Float_t _t0, _t0err; // time of helix at z=0 [ns]
     TrkFitInfo() { reset(); }
-    void reset() { _mom=_momerr=-1000.0; _minr=_maxr=_pitch=_rad=_raderr=_lam=_lamerr=_cx=_cxerr=_cy=_cyerr=_phi0=_phi0err=_t0=_t0err=0; }
+    void reset() { _mom=_momerr=-1000.0; _minr=_maxr=_pitch=_time=_phi=_rad=_raderr=_lam=_lamerr=_cx=_cxerr=_cy=_cyerr=_phi0=_phi0err=_t0=_t0err=0; }
     static std::string leafnames() {
       static std::string leaves;
-      leaves = std::string("mom/F:momerr/F:minr/F:maxr/F:pitch/F:rad/F:raderr/F:lam/F:lamerr/F:cx/F:cxerr/F:cy/F:cyerr/F:phi0/F:phi0err/F:t0/F:t0err/F");
+      leaves = std::string("mom/F:momerr/F:minr/F:maxr/F:pitch/F:time/F:phi/F:rad/F:raderr/F:lam/F:lamerr/F:cx/F:cxerr/F:cy/F:cyerr/F:phi0/F:phi0err/F:t0/F:t0err/F");
       return leaves;
     }
   };

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -50,8 +50,6 @@ namespace mu2e
     Int_t _nnullambig;  // number of hits without any ambiguity assigned
     Int_t _nmat, _nmatactive; // number materials (straw) assigned and used (active) to this fit
     Int_t _nseg;     // number of trajectory segments 
-    Float_t _t0;      // time this particle was estimated to cross z=0
-    Float_t _t0err;   // error on t0
     Float_t _chisq;   // Kalman fit chisquared
     Float_t _fitcon;  // Kalman fit chisqured consistency
     Float_t _radlen;  // total radiation length of (active) material crossed by this particle inside the tracker
@@ -64,12 +62,12 @@ namespace mu2e
       _alg=0;
       _pdg = 0;
       _nhits = _nactive = _ndouble = _ndactive = _nnullambig = _nmat = _nmatactive = _nseg = _ndof = -1;
-      _t0 = _t0err = _chisq = _fitcon = _radlen = _firstflt = _lastflt = -1.0;
+      _chisq = _fitcon = _radlen = _firstflt = _lastflt = -1.0;
       _trkqual=-1000.0;
       _startvalid = _endvalid = -999999.0;
     }
     static std::string const& leafnames() { static const std::string leaves =
-    std::string("status/I:alg/I:pdg/I:nhits/I:ndof/I:nactive/I:ndouble/I:ndactive/I:nnullambig/I:nmat/I:nmatactive/I:nseg/I:t0/F:t0err/F:chisq/F:fitcon/F:radlen/F:firstflt/F:lastflt/F:startvalid/F:endvalid/F");
+    std::string("status/I:alg/I:pdg/I:nhits/I:ndof/I:nactive/I:ndouble/I:ndactive/I:nnullambig/I:nmat/I:nmatactive/I:nseg/I:chisq/F:fitcon/F:radlen/F:firstflt/F:lastflt/F:startvalid/F:endvalid/F");
      return leaves;
     }
   };

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -23,12 +23,13 @@ namespace mu2e
     Float_t _lam, _lamerr;
     Float_t _cx, _cxerr;
     Float_t _cy, _cyerr;
+    Float_t _phi0, _phi0err;
     Float_t _t0, _t0err;
     TrkFitInfo() { reset(); }
-    void reset() { _mom=_momerr=-1000.0; _minr=_maxr=_pitch=_rad=_raderr=_lam=_lamerr=_cx=_cxerr=_cy=_cyerr=_t0=_t0err=0; }
+    void reset() { _mom=_momerr=-1000.0; _minr=_maxr=_pitch=_rad=_raderr=_lam=_lamerr=_cx=_cxerr=_cy=_cyerr=_phi0=_phi0err=_t0=_t0err=0; }
     static std::string leafnames() {
       static std::string leaves;
-      leaves = std::string("mom/F:momerr/F:minr/F:maxr/F:pitch/F:rad/F:raderr/F:lam/F:lamerr/F:cx/F:cxerr/F:cy/F:cyerr/F:t0/F:t0err/F");
+      leaves = std::string("mom/F:momerr/F:minr/F:maxr/F:pitch/F:rad/F:raderr/F:lam/F:lamerr/F:cx/F:cxerr/F:cy/F:cyerr/F:phi0/F:phi0err/F:t0/F:t0err/F");
       return leaves;
     }
   };

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -26,6 +26,18 @@ namespace mu2e
     }
   };
 
+  struct TrkFitInfoKK {
+    Float_t _mom, _momerr;
+    Float_t _rad, _raderr;
+    TrkFitInfoKK() { reset(); }
+    void reset() { _mom=_momerr=-1000.0; _rad=_raderr=0; }
+    static std::string leafnames() {
+      static std::string leaves;
+      leaves = std::string("mom/F:momerr/F:rad/F:raderr/F");
+      return leaves;
+    }
+  };
+
 // general information about a track
   struct TrkInfo {
     Int_t _status; // Kalman fit status

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -27,13 +27,20 @@ namespace mu2e
   };
 
   struct TrkFitInfoKK {
-    Float_t _mom, _momerr;
+    Float_t _mom, _momerr; // momentum and its uncertinaty [MeV/c]
+    Float_t _minr; // minimum radius of the helix [mm]
+    Float_t _maxr; // maximum radius of the helix [mm]
+    Float_t _pitch; // pitch angle [rad]
     Float_t _rad, _raderr;
+    Float_t _lam, _lamerr;
+    Float_t _cx, _cxerr;
+    Float_t _cy, _cyerr;
+    Float_t _t0, _t0err;
     TrkFitInfoKK() { reset(); }
-    void reset() { _mom=_momerr=-1000.0; _rad=_raderr=0; }
+    void reset() { _mom=_momerr=-1000.0; _minr=_maxr=_pitch=_rad=_raderr=_lam=_lamerr=_cx=_cxerr=_cy=_cyerr=_t0=_t0err=0; }
     static std::string leafnames() {
       static std::string leaves;
-      leaves = std::string("mom/F:momerr/F:rad/F:raderr/F");
+      leaves = std::string("mom/F:momerr/F:minr/F:maxr/F:pitch/F:rad/F:raderr/F:lam/F:lamerr/F:cx/F:cxerr/F:cy/F:cyerr/F:t0/F:t0err/F");
       return leaves;
     }
   };

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -112,6 +112,10 @@ namespace mu2e {
         trkprimary = trkprimary.parent()->originParticle();
       }
       else {
+        // clear the SimInfos for higher generations since they may have been filled with a previous track in this event
+        for (int j_generation = i_generation+1; j_generation < n_generations; ++j_generation) {
+          siminfos.at(j_generation).reset();
+        }
         break; // this particle doesn't have a parent
       }
     }

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -72,13 +72,14 @@ namespace mu2e {
     double firstflt = 9999999;
     double lastflt = -9999999;
     for (const auto& kseg : kseed.segments()) {
-      //	std::cout << "AE: min = " << kseg.fmin() << ", max = " << kseg.fmax() << std::endl;
+      //      std::cout << "AE: min = " << kseg.fmin() << ", max = " << kseg.fmax() << std::endl;
       if (kseg.globalFlt(kseg.fmin()) < firstflt) {
 	firstflt = kseg.globalFlt(kseg.fmin());
       }
       if (kseg.globalFlt(kseg.fmax()) > lastflt) {
 	lastflt = kseg.globalFlt(kseg.fmax());
       }
+      //      std::cout << "AE: " << kseg.loopHelix().rad() << " " << kseg.loopHelix().lam() << s" " << kseg.loopHelix().cx() << " " << kseg.loopHelix().cy() << " " << kseg.loopHelix().phi0() << " " << kseg.loopHelix().t0() << std::endl;
     }
     trkinfo._startvalid = firstflt;
     trkinfo._endvalid = lastflt;
@@ -86,7 +87,7 @@ namespace mu2e {
     fillTrkInfoStraws(kseed, trkinfo);
   }
 
-  void InfoStructHelper::fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVectorF& pos) {
+  void InfoStructHelper::fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, TrkFitInfoKK& trkfitinfokk, const XYZVectorF& pos) {
     const auto& ksegIter = kseed.nearestSegment(pos);
     if (ksegIter == kseed.segments().end()) {
       cet::exception("InfoStructHelper") << "Couldn't find KalSegment that includes pos = " << pos;
@@ -97,6 +98,11 @@ namespace mu2e {
     CLHEP::HepSymMatrix pcov;
     ksegIter->covar().symMatrix(pcov);
     trkfitinfo._fitparerr = helixpar(pcov);
+
+    trkfitinfokk._mom = ksegIter->loopHelix().momentum();
+    trkfitinfokk._momerr = std::sqrt(ksegIter->loopHelix().momentumVariance());
+    trkfitinfokk._rad = ksegIter->loopHelix().rad();
+    trkfitinfokk._raderr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::rad_));
   }
 
   void InfoStructHelper::fillTrkInfoHits(const KalSeed& kseed, TrkInfo& trkinfo) {

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -6,6 +6,7 @@
 #include "Offline/RecoDataProducts/inc/TrkStrawHitSeed.hh"
 
 #include "Offline/TrackerGeom/inc/Tracker.hh"
+#include "KinKal/Trajectory/POCAUtil.hh"
 #include <cmath>
 
 namespace mu2e {
@@ -103,6 +104,18 @@ namespace mu2e {
     trkfitinfokk._momerr = std::sqrt(ksegIter->loopHelix().momentumVariance());
     trkfitinfokk._rad = ksegIter->loopHelix().rad();
     trkfitinfokk._raderr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::rad_));
+    trkfitinfokk._lam = ksegIter->loopHelix().lam();
+    trkfitinfokk._lamerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::lam_));
+    trkfitinfokk._cx = ksegIter->loopHelix().cx();
+    trkfitinfokk._cxerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cx_));
+    trkfitinfokk._cy = ksegIter->loopHelix().cy();
+    trkfitinfokk._cyerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cy_));
+    trkfitinfokk._t0 = ksegIter->loopHelix().ztime(ksegIter->position3().z());
+    trkfitinfokk._t0err = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::t0_));
+
+    trkfitinfokk._minr = std::sqrt(trkfitinfokk._cx*trkfitinfokk._cx + trkfitinfokk._cy*trkfitinfokk._cy) - trkfitinfokk._rad;
+    trkfitinfokk._maxr = std::sqrt(trkfitinfokk._cx*trkfitinfokk._cx + trkfitinfokk._cy*trkfitinfokk._cy) + trkfitinfokk._rad;
+    trkfitinfokk._pitch = std::atan2(trkfitinfokk._maxr, (0.5*trkfitinfokk._lam));
   }
 
   void InfoStructHelper::fillTrkInfoHits(const KalSeed& kseed, TrkInfo& trkinfo) {

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -88,34 +88,27 @@ namespace mu2e {
     fillTrkInfoStraws(kseed, trkinfo);
   }
 
-  void InfoStructHelper::fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, TrkFitInfoKK& trkfitinfokk, const XYZVectorF& pos) {
+  void InfoStructHelper::fillTrkFitInfo(const KalSeed& kseed,TrkFitInfo& trkfitinfo, const XYZVectorF& pos) {
     const auto& ksegIter = kseed.nearestSegment(pos);
     if (ksegIter == kseed.segments().end()) {
       cet::exception("InfoStructHelper") << "Couldn't find KalSegment that includes pos = " << pos;
     }
-    trkfitinfo._fitmom = ksegIter->mom();
-    trkfitinfo._fitmomerr = ksegIter->momerr();
-    trkfitinfo._fitpar = ksegIter->helix();
-    CLHEP::HepSymMatrix pcov;
-    ksegIter->covar().symMatrix(pcov);
-    trkfitinfo._fitparerr = helixpar(pcov);
+    trkfitinfo._mom = ksegIter->loopHelix().momentum();
+    trkfitinfo._momerr = std::sqrt(ksegIter->loopHelix().momentumVariance());
+    trkfitinfo._rad = ksegIter->loopHelix().rad();
+    trkfitinfo._raderr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::rad_));
+    trkfitinfo._lam = ksegIter->loopHelix().lam();
+    trkfitinfo._lamerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::lam_));
+    trkfitinfo._cx = ksegIter->loopHelix().cx();
+    trkfitinfo._cxerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cx_));
+    trkfitinfo._cy = ksegIter->loopHelix().cy();
+    trkfitinfo._cyerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cy_));
+    trkfitinfo._t0 = ksegIter->loopHelix().ztime(ksegIter->position3().z());
+    trkfitinfo._t0err = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::t0_));
 
-    trkfitinfokk._mom = ksegIter->loopHelix().momentum();
-    trkfitinfokk._momerr = std::sqrt(ksegIter->loopHelix().momentumVariance());
-    trkfitinfokk._rad = ksegIter->loopHelix().rad();
-    trkfitinfokk._raderr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::rad_));
-    trkfitinfokk._lam = ksegIter->loopHelix().lam();
-    trkfitinfokk._lamerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::lam_));
-    trkfitinfokk._cx = ksegIter->loopHelix().cx();
-    trkfitinfokk._cxerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cx_));
-    trkfitinfokk._cy = ksegIter->loopHelix().cy();
-    trkfitinfokk._cyerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cy_));
-    trkfitinfokk._t0 = ksegIter->loopHelix().ztime(ksegIter->position3().z());
-    trkfitinfokk._t0err = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::t0_));
-
-    trkfitinfokk._minr = std::sqrt(trkfitinfokk._cx*trkfitinfokk._cx + trkfitinfokk._cy*trkfitinfokk._cy) - trkfitinfokk._rad;
-    trkfitinfokk._maxr = std::sqrt(trkfitinfokk._cx*trkfitinfokk._cx + trkfitinfokk._cy*trkfitinfokk._cy) + trkfitinfokk._rad;
-    trkfitinfokk._pitch = std::atan2(trkfitinfokk._maxr, (0.5*trkfitinfokk._lam));
+    trkfitinfo._minr = std::sqrt(trkfitinfo._cx*trkfitinfo._cx + trkfitinfo._cy*trkfitinfo._cy) - trkfitinfo._rad;
+    trkfitinfo._maxr = std::sqrt(trkfitinfo._cx*trkfitinfo._cx + trkfitinfo._cy*trkfitinfo._cy) + trkfitinfo._rad;
+    trkfitinfo._pitch = std::atan2(trkfitinfo._maxr, (0.5*trkfitinfo._lam));
   }
 
   void InfoStructHelper::fillTrkInfoHits(const KalSeed& kseed, TrkInfo& trkinfo) {

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -108,7 +108,7 @@ namespace mu2e {
 
     trkfitinfo._minr = std::sqrt(trkfitinfo._cx*trkfitinfo._cx + trkfitinfo._cy*trkfitinfo._cy) - trkfitinfo._rad;
     trkfitinfo._maxr = std::sqrt(trkfitinfo._cx*trkfitinfo._cx + trkfitinfo._cy*trkfitinfo._cy) + trkfitinfo._rad;
-    trkfitinfo._pitch = std::atan2(trkfitinfo._maxr, (0.5*trkfitinfo._lam));
+    trkfitinfo._pitch = std::atan2(trkfitinfo._maxr, trkfitinfo._lam);
   }
 
   void InfoStructHelper::fillTrkInfoHits(const KalSeed& kseed, TrkInfo& trkinfo) {

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -32,7 +32,7 @@ namespace mu2e {
     hitcount._ntpk = nrec._nshftpk;
   }
 
-  void InfoStructHelper::fillTrkInfo(const KalSeed& kseed,TrkInfo& trkinfo) {
+  void InfoStructHelper::fillTrkInfo(const KalSeed& kseed,TrkInfo& trkinfo, const XYZVectorF& pos) {
     if(kseed.status().hasAllProperties(TrkFitFlag::kalmanConverged))
       trkinfo._status = 1;
     else if(kseed.status().hasAllProperties(TrkFitFlag::kalmanOK))
@@ -78,6 +78,20 @@ namespace mu2e {
 	lastflt = kseg.globalFlt(kseg.fmax());
       }
     }
+
+    const auto& ksegIter = kseed.nearestSegment(pos);
+    double cx = ksegIter->loopHelix().cx();
+    double cy = ksegIter->loopHelix().cy();
+    double rad = ksegIter->loopHelix().rad();
+    double lam = ksegIter->loopHelix().lam();
+    trkinfo._mom = ksegIter->loopHelix().momentum();
+    trkinfo._momerr = std::sqrt(ksegIter->loopHelix().momentumVariance());
+    trkinfo._minr = std::sqrt(cx*cx + cy*cy) - rad;
+    trkinfo._maxr = std::sqrt(cx*cx + cy*cy) + rad;
+    trkinfo._pitch = std::atan2(trkinfo._maxr, lam);
+    trkinfo._time = ksegIter->loopHelix().ztime(ksegIter->position3().z());
+    trkinfo._phi = ksegIter->loopHelix().zphi(ksegIter->position3().z());
+
     trkinfo._startvalid = firstflt;
     trkinfo._endvalid = lastflt;
 
@@ -104,9 +118,6 @@ namespace mu2e {
     trkfitinfo._t0 = ksegIter->loopHelix().t0();
     trkfitinfo._t0err = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::t0_));
 
-    trkfitinfo._minr = std::sqrt(trkfitinfo._cx*trkfitinfo._cx + trkfitinfo._cy*trkfitinfo._cy) - trkfitinfo._rad;
-    trkfitinfo._maxr = std::sqrt(trkfitinfo._cx*trkfitinfo._cx + trkfitinfo._cy*trkfitinfo._cy) + trkfitinfo._rad;
-    trkfitinfo._pitch = std::atan2(trkfitinfo._maxr, trkfitinfo._lam);
     trkfitinfo._time = ksegIter->loopHelix().ztime(ksegIter->position3().z());
     trkfitinfo._phi = ksegIter->loopHelix().zphi(ksegIter->position3().z());
   }

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -47,8 +47,6 @@ namespace mu2e {
       trkinfo._alg = -1;
 
     trkinfo._pdg = kseed.particle();
-    trkinfo._t0 = kseed.t0().t0();
-    trkinfo._t0err = kseed.t0().t0Err();
 
     fillTrkInfoHits(kseed, trkinfo);
 

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -71,14 +71,12 @@ namespace mu2e {
     double firstflt = 9999999;
     double lastflt = -9999999;
     for (const auto& kseg : kseed.segments()) {
-      //      std::cout << "AE: min = " << kseg.fmin() << ", max = " << kseg.fmax() << std::endl;
       if (kseg.globalFlt(kseg.fmin()) < firstflt) {
 	firstflt = kseg.globalFlt(kseg.fmin());
       }
       if (kseg.globalFlt(kseg.fmax()) > lastflt) {
 	lastflt = kseg.globalFlt(kseg.fmax());
       }
-      //      std::cout << "AE: " << kseg.loopHelix().rad() << " " << kseg.loopHelix().lam() << s" " << kseg.loopHelix().cx() << " " << kseg.loopHelix().cy() << " " << kseg.loopHelix().phi0() << " " << kseg.loopHelix().t0() << std::endl;
     }
     trkinfo._startvalid = firstflt;
     trkinfo._endvalid = lastflt;

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -103,6 +103,8 @@ namespace mu2e {
     trkfitinfo._cxerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cx_));
     trkfitinfo._cy = ksegIter->loopHelix().cy();
     trkfitinfo._cyerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cy_));
+    trkfitinfo._phi0 = ksegIter->loopHelix().phi0();
+    trkfitinfo._phi0err = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::phi0_));
     trkfitinfo._t0 = ksegIter->loopHelix().ztime(ksegIter->position3().z());
     trkfitinfo._t0err = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::t0_));
 

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -105,12 +105,14 @@ namespace mu2e {
     trkfitinfo._cyerr = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::cy_));
     trkfitinfo._phi0 = ksegIter->loopHelix().phi0();
     trkfitinfo._phi0err = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::phi0_));
-    trkfitinfo._t0 = ksegIter->loopHelix().ztime(ksegIter->position3().z());
+    trkfitinfo._t0 = ksegIter->loopHelix().t0();
     trkfitinfo._t0err = std::sqrt(ksegIter->loopHelix().paramVar(KinKal::LoopHelix::ParamIndex::t0_));
 
     trkfitinfo._minr = std::sqrt(trkfitinfo._cx*trkfitinfo._cx + trkfitinfo._cy*trkfitinfo._cy) - trkfitinfo._rad;
     trkfitinfo._maxr = std::sqrt(trkfitinfo._cx*trkfitinfo._cx + trkfitinfo._cy*trkfitinfo._cy) + trkfitinfo._rad;
     trkfitinfo._pitch = std::atan2(trkfitinfo._maxr, trkfitinfo._lam);
+    trkfitinfo._time = ksegIter->loopHelix().ztime(ksegIter->position3().z());
+    trkfitinfo._phi = ksegIter->loopHelix().zphi(ksegIter->position3().z());
   }
 
   void InfoStructHelper::fillTrkInfoHits(const KalSeed& kseed, TrkInfo& trkinfo) {

--- a/src/SConscript
+++ b/src/SConscript
@@ -31,7 +31,8 @@ mainlib = helper.make_mainlib ( [
     'mu2e_MCDataProducts',
     'mu2e_RecoDataProducts',
     'mu2e_CalorimeterGeom',
-    'General'
+    'General',
+    'Trajectory'
 ] )
 
 # Fixme: split into link lists for each module.

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -188,7 +188,6 @@ namespace mu2e {
     // track branches (outputs)
     std::vector<TrkInfo> _allTIs;
     std::vector<TrkFitInfo> _allEntTIs, _allMidTIs, _allXitTIs;
-    std::vector<TrkFitInfoKK> _allEntTIKKs, _allMidTIKKs, _allXitTIKKs;
     std::vector<TrkCaloHitInfo> _allTCHIs;
     // quality branches (inputs)
     std::vector<std::vector<art::Handle<RecoQualCollection> > > _allRQCHs; // outer vector is for each candidate/supplement, inner vector is all RecoQuals
@@ -284,11 +283,6 @@ namespace mu2e {
       _allMidTIs.push_back(mid);
       _allXitTIs.push_back(xit);
 
-      TrkFitInfoKK entkk, midkk, xitkk;
-      _allEntTIKKs.push_back(entkk);
-      _allMidTIKKs.push_back(midkk);
-      _allXitTIKKs.push_back(xitkk);
-
       TrkCaloHitInfo tchi;
       _allTCHIs.push_back(tchi);
 
@@ -350,9 +344,6 @@ namespace mu2e {
       _trkana->Branch((branch+"ent").c_str(),&_allEntTIs.at(i_branch),TrkFitInfo::leafnames().c_str());
       _trkana->Branch((branch+"mid").c_str(),&_allMidTIs.at(i_branch),TrkFitInfo::leafnames().c_str());
       _trkana->Branch((branch+"xit").c_str(),&_allXitTIs.at(i_branch),TrkFitInfo::leafnames().c_str());
-      _trkana->Branch((branch+"entkk").c_str(),&_allEntTIKKs.at(i_branch),TrkFitInfoKK::leafnames().c_str());
-      _trkana->Branch((branch+"midkk").c_str(),&_allMidTIKKs.at(i_branch),TrkFitInfoKK::leafnames().c_str());
-      _trkana->Branch((branch+"xitkk").c_str(),&_allXitTIKKs.at(i_branch),TrkFitInfoKK::leafnames().c_str());
       _trkana->Branch((branch+"tch").c_str(),&_allTCHIs.at(i_branch),TrkCaloHitInfo::leafnames().c_str());
       if (_conf.filltrkqual() && i_branchConfig.options().filltrkqual()) {
         _trkana->Branch((branch+"trkqual").c_str(), &_allTQIs.at(i_branch), TrkQualInfo::leafnames().c_str());
@@ -711,9 +702,9 @@ namespace mu2e {
     const XYZVectorF& xitpos = XYZVectorF(det->toDetector(vdHandle->getGlobal(*_xitvids.begin())));
 
     _infoStructHelper.fillTrkInfo(kseed,_allTIs.at(i_branch));
-    _infoStructHelper.fillTrkFitInfo(kseed,_allEntTIs.at(i_branch),_allEntTIKKs.at(i_branch),entpos);
-    _infoStructHelper.fillTrkFitInfo(kseed,_allMidTIs.at(i_branch),_allMidTIKKs.at(i_branch),midpos);
-    _infoStructHelper.fillTrkFitInfo(kseed,_allXitTIs.at(i_branch),_allXitTIKKs.at(i_branch),xitpos);
+    _infoStructHelper.fillTrkFitInfo(kseed,_allEntTIs.at(i_branch),entpos);
+    _infoStructHelper.fillTrkFitInfo(kseed,_allMidTIs.at(i_branch),midpos);
+    _infoStructHelper.fillTrkFitInfo(kseed,_allXitTIs.at(i_branch),xitpos);
     //      _tcnt._overlaps[0] = _tcomp.nOverlap(kseed, kseed);
 
     if(_conf.diag() > 1 || (_conf.fillhits() && branchConfig.options().fillhits())){ // want hit level info
@@ -846,10 +837,6 @@ namespace mu2e {
       _allEntTIs.at(i_branch).reset();
       _allMidTIs.at(i_branch).reset();
       _allXitTIs.at(i_branch).reset();
-
-      _allEntTIKKs.at(i_branch).reset();
-      _allMidTIKKs.at(i_branch).reset();
-      _allXitTIKKs.at(i_branch).reset();
 
       _allTCHIs.at(i_branch).reset();
 

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -188,6 +188,7 @@ namespace mu2e {
     // track branches (outputs)
     std::vector<TrkInfo> _allTIs;
     std::vector<TrkFitInfo> _allEntTIs, _allMidTIs, _allXitTIs;
+    std::vector<TrkFitInfoKK> _allEntTIKKs, _allMidTIKKs, _allXitTIKKs;
     std::vector<TrkCaloHitInfo> _allTCHIs;
     // quality branches (inputs)
     std::vector<std::vector<art::Handle<RecoQualCollection> > > _allRQCHs; // outer vector is for each candidate/supplement, inner vector is all RecoQuals
@@ -283,6 +284,11 @@ namespace mu2e {
       _allMidTIs.push_back(mid);
       _allXitTIs.push_back(xit);
 
+      TrkFitInfoKK entkk, midkk, xitkk;
+      _allEntTIKKs.push_back(entkk);
+      _allMidTIKKs.push_back(midkk);
+      _allXitTIKKs.push_back(xitkk);
+
       TrkCaloHitInfo tchi;
       _allTCHIs.push_back(tchi);
 
@@ -344,6 +350,9 @@ namespace mu2e {
       _trkana->Branch((branch+"ent").c_str(),&_allEntTIs.at(i_branch),TrkFitInfo::leafnames().c_str());
       _trkana->Branch((branch+"mid").c_str(),&_allMidTIs.at(i_branch),TrkFitInfo::leafnames().c_str());
       _trkana->Branch((branch+"xit").c_str(),&_allXitTIs.at(i_branch),TrkFitInfo::leafnames().c_str());
+      _trkana->Branch((branch+"entkk").c_str(),&_allEntTIKKs.at(i_branch),TrkFitInfoKK::leafnames().c_str());
+      _trkana->Branch((branch+"midkk").c_str(),&_allMidTIKKs.at(i_branch),TrkFitInfoKK::leafnames().c_str());
+      _trkana->Branch((branch+"xitkk").c_str(),&_allXitTIKKs.at(i_branch),TrkFitInfoKK::leafnames().c_str());
       _trkana->Branch((branch+"tch").c_str(),&_allTCHIs.at(i_branch),TrkCaloHitInfo::leafnames().c_str());
       if (_conf.filltrkqual() && i_branchConfig.options().filltrkqual()) {
         _trkana->Branch((branch+"trkqual").c_str(), &_allTQIs.at(i_branch), TrkQualInfo::leafnames().c_str());
@@ -702,9 +711,9 @@ namespace mu2e {
     const XYZVectorF& xitpos = XYZVectorF(det->toDetector(vdHandle->getGlobal(*_xitvids.begin())));
 
     _infoStructHelper.fillTrkInfo(kseed,_allTIs.at(i_branch));
-    _infoStructHelper.fillTrkFitInfo(kseed,_allEntTIs.at(i_branch),entpos);
-    _infoStructHelper.fillTrkFitInfo(kseed,_allMidTIs.at(i_branch),midpos);
-    _infoStructHelper.fillTrkFitInfo(kseed,_allXitTIs.at(i_branch),xitpos);
+    _infoStructHelper.fillTrkFitInfo(kseed,_allEntTIs.at(i_branch),_allEntTIKKs.at(i_branch),entpos);
+    _infoStructHelper.fillTrkFitInfo(kseed,_allMidTIs.at(i_branch),_allMidTIKKs.at(i_branch),midpos);
+    _infoStructHelper.fillTrkFitInfo(kseed,_allXitTIs.at(i_branch),_allXitTIKKs.at(i_branch),xitpos);
     //      _tcnt._overlaps[0] = _tcomp.nOverlap(kseed, kseed);
 
     if(_conf.diag() > 1 || (_conf.fillhits() && branchConfig.options().fillhits())){ // want hit level info
@@ -837,6 +846,10 @@ namespace mu2e {
       _allEntTIs.at(i_branch).reset();
       _allMidTIs.at(i_branch).reset();
       _allXitTIs.at(i_branch).reset();
+
+      _allEntTIKKs.at(i_branch).reset();
+      _allMidTIKKs.at(i_branch).reset();
+      _allXitTIKKs.at(i_branch).reset();
 
       _allTCHIs.at(i_branch).reset();
 

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -701,7 +701,7 @@ namespace mu2e {
     const XYZVectorF& midpos = XYZVectorF(det->toDetector(vdHandle->getGlobal(*_midvids.begin())));
     const XYZVectorF& xitpos = XYZVectorF(det->toDetector(vdHandle->getGlobal(*_xitvids.begin())));
 
-    _infoStructHelper.fillTrkInfo(kseed,_allTIs.at(i_branch));
+    _infoStructHelper.fillTrkInfo(kseed,_allTIs.at(i_branch),entpos);// fill summary information defined at entrance
     _infoStructHelper.fillTrkFitInfo(kseed,_allEntTIs.at(i_branch),entpos);
     _infoStructHelper.fillTrkFitInfo(kseed,_allMidTIs.at(i_branch),midpos);
     _infoStructHelper.fillTrkFitInfo(kseed,_allXitTIs.at(i_branch),xitpos);


### PR DESCRIPTION
Looking at the new CeEndpointMix MDC2020km, I found a bug relating to genealogy for events with more than one track. I saw reconstructed true DIOs (`demcsim.gen==114`) with a filled `demcgparent` branch even though these DIO events were from the background frame where we compress away the genealogy. The issue was that there was also a conversion electron reconstructed in the same event, which does have real `demcgparent` information, and so the `demcgparent` branch wasn't being reset between tracks. This PR implements a fix for this issue.