### PR TITLE
Fix bug in genealogy branches

### DIFF
--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -112,6 +112,10 @@ namespace mu2e {
         trkprimary = trkprimary.parent()->originParticle();
       }
       else {
+        // clear the SimInfos for higher generations since they may have been filled with a previous track in this event
+        for (int j_generation = i_generation+1; j_generation < n_generations; ++j_generation) {
+          siminfos.at(j_generation).reset();
+        }
         break; // this particle doesn't have a parent
       }
     }


### PR DESCRIPTION
Looking at the new CeEndpointMix MDC2020km, I found a bug relating to genealogy for events with more than one track. I saw reconstructed true DIOs (`demcsim.gen==114`) with a filled `demcgparent` branch even though these DIO events were from the background frame where we compress away the genealogy. The issue was that there was also a conversion electron reconstructed in the same event, which does have real `demcgparent` information, and so the `demcgparent` branch wasn't being reset between tracks. This PR implements a fix for this issue.