### PR TITLE
Make a more general fix that also solves the demcent issues I saw

### DIFF
--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -112,10 +112,6 @@ namespace mu2e {
         trkprimary = trkprimary.parent()->originParticle();
       }
       else {
-        // clear the SimInfos for higher generations since they may have been filled with a previous track in this event
-        for (int j_generation = i_generation+1; j_generation < n_generations; ++j_generation) {
-          siminfos.at(j_generation).reset();
-        }
         break; // this particle doesn't have a parent
       }
     }

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -241,7 +241,7 @@ namespace mu2e {
     // helper functions
     void fillEventInfo(const art::Event& event);
     void fillTriggerBits(const art::Event& event,std::string const& process);
-    void resetBranches();
+    void resetTrackBranches();
     size_t findSupplementTrack(KalSeedCollection const& kcol,KalSeed const& candidate, bool sameColl);
     void fillAllInfos(const art::Handle<KalSeedCollection>& ksch, size_t i_branch, size_t i_kseed);
 
@@ -513,7 +513,7 @@ namespace mu2e {
     _hinfo.reset();
     _wtinfo.reset();
     // reset
-    resetBranches();
+    resetTrackBranches();
     // fill track counts
     for (size_t i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {
       _tcnt._counts[i_branch] = (_allKSCHs.at(i_branch))->size();
@@ -527,6 +527,7 @@ namespace mu2e {
     const auto& candidateKSCH = _allKSCHs.at(_candidateIndex);
     const auto& candidateKSC = *candidateKSCH;
     for (size_t i_kseed = 0; i_kseed < candidateKSC.size(); ++i_kseed) {
+      resetTrackBranches(); // reset track branches here so that we don't get information from previous tracks in the next entry
 
       bool skip_kseed = false; // there may be a reason we don't want to write this KalSeed out
 
@@ -831,7 +832,7 @@ namespace mu2e {
     return outputHandles;
   }
 
-  void TrkAnaTreeMaker::resetBranches() {
+  void TrkAnaTreeMaker::resetTrackBranches() {
     for (size_t i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {
       _allTIs.at(i_branch).reset();
       _allEntTIs.at(i_branch).reset();


### PR DESCRIPTION
Following PR#34 where I was seeing `demcparent` information not being cleared between entries in the TTree. I then saw the same thing for `demcent` branches like this:
```
************************************************************************************************
*    Row   * evtinfo.s * evtinfo.e *  deent.t0 * deent.mom * demcent.mom * demcsim.mom * demcsim.gen *
************************************************************************************************
...
*     7274 *         2 *      1741 * 1033.1876 * 45.835845 *        -1   * 49.220714   *       114   *
*     7275 *         2 *      1741 * 527.11590 * 104.34414 * 104.40641   * 104.97261   *       167   *
*     7276 *         2 *      1741 * 1147.5893 * 79.371154 * 104.40641   * 78.951782   *       166   *
```
where the final track is keeping the `demcent.mom` from the Ce (114 = "DIO", 167 = "mu2eCeMinusEndpoitn", "166="mu2eMuonDecayAtRest").

To solve this and the previous issue, I do a more fundamental fix that solves both problems. I have also renamed the `resetBranches` function to `resetTrackBranches` for clarity.