### PR TITLE
Add include to fix valJobSecondary failure

### DIFF
--- a/inc/InfoStructHelper.hh
+++ b/inc/InfoStructHelper.hh
@@ -9,6 +9,7 @@
 #include "Offline/RecoDataProducts/inc/StrawHitFlag.hh"
 #include "Offline/RecoDataProducts/inc/TrkQual.hh"
 #include "Offline/RecoDataProducts/inc/RecoCount.hh"
+#include "Offline/RecoDataProducts/inc/HelixSeed.hh"
 
 #include "Offline/BFieldGeom/inc/BFieldManager.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"


### PR DESCRIPTION
The valJobSecondary build test failed on 2021-10-28 because of a missing include. I've added the include line and now it builds with the latest Offline. I guess this file was included through another header before.