### PR TITLE
CRV-related Changes

### DIFF
--- a/fcl/CrvExpert.fcl
+++ b/fcl/CrvExpert.fcl
@@ -1,7 +1,7 @@
 #include "TrkAna/fcl/TrkAnaReco.fcl"
 
-physics.analyzers.TrkAnaNeg.AnalyzeCRVHits : true
-physics.analyzers.TrkAnaNeg.AnalyzeCRVPulses : false
+physics.analyzers.TrkAnaNeg.FillCRVHits : true
+physics.analyzers.TrkAnaNeg.FillCRVPulses : false
 
-physics.analyzers.TrkAnaPos.AnalyzeCRVHits : true
-physics.analyzers.TrkAnaPos.AnalyzeCRVPulses : false
+physics.analyzers.TrkAnaPos.FillCRVHits : true
+physics.analyzers.TrkAnaPos.FillCRVPulses : false

--- a/fcl/CrvExpert.fcl
+++ b/fcl/CrvExpert.fcl
@@ -1,0 +1,7 @@
+#include "TrkAna/fcl/TrkAnaReco.fcl"
+
+physics.analyzers.TrkAnaNeg.AnalyzeCRVHits : true
+physics.analyzers.TrkAnaNeg.AnalyzeCRVPulses : false
+
+physics.analyzers.TrkAnaPos.AnalyzeCRVHits : true
+physics.analyzers.TrkAnaPos.AnalyzeCRVPulses : false

--- a/fcl/TrkAnaReco.fcl
+++ b/fcl/TrkAnaReco.fcl
@@ -26,12 +26,10 @@ physics.analyzers.TrkAnaPos.candidate.options : @local::AllOpt
 physics.analyzers.TrkAnaNeg.diagLevel : 1
 physics.analyzers.TrkAnaNeg.FillMCInfo : true
 physics.analyzers.TrkAnaNeg.AnalyzeCRV : true
-physics.analyzers.TrkAnaNeg.AnalyzeCRVPulses : false
 physics.analyzers.TrkAnaNeg.FillTriggerInfo : false
 physics.analyzers.TrkAnaPos.diagLevel : 1
 physics.analyzers.TrkAnaPos.FillMCInfo : true
 physics.analyzers.TrkAnaPos.AnalyzeCRV : true
-physics.analyzers.TrkAnaPos.AnalyzeCRVPulses : false
 physics.analyzers.TrkAnaPos.FillTriggerInfo : false
 
 services.TFileService.fileName: "nts.owner.trkana-reco.version.sequencer.root"

--- a/fcl/TrkAnaReco.fcl
+++ b/fcl/TrkAnaReco.fcl
@@ -25,11 +25,11 @@ physics.analyzers.TrkAnaPos.candidate.options : @local::AllOpt
 # for hit level diagnostics, set diagLevel to 2
 physics.analyzers.TrkAnaNeg.diagLevel : 1
 physics.analyzers.TrkAnaNeg.FillMCInfo : true
-physics.analyzers.TrkAnaNeg.AnalyzeCRV : true
+physics.analyzers.TrkAnaNeg.FillCRV : true
 physics.analyzers.TrkAnaNeg.FillTriggerInfo : false
 physics.analyzers.TrkAnaPos.diagLevel : 1
 physics.analyzers.TrkAnaPos.FillMCInfo : true
-physics.analyzers.TrkAnaPos.AnalyzeCRV : true
+physics.analyzers.TrkAnaPos.FillCRV : true
 physics.analyzers.TrkAnaPos.FillTriggerInfo : false
 
 services.TFileService.fileName: "nts.owner.trkana-reco.version.sequencer.root"

--- a/fcl/TrkAnaReco_wTrkQualFilter.fcl
+++ b/fcl/TrkAnaReco_wTrkQualFilter.fcl
@@ -53,11 +53,11 @@ physics.analyzers.TrkAnaPos.candidate.options : @local::AllOpt
 # for hit level diagnostics, set diagLevel to 2
 physics.analyzers.TrkAnaNeg.diagLevel : 1
 physics.analyzers.TrkAnaNeg.FillMCInfo : true
-physics.analyzers.TrkAnaNeg.AnalyzeCRV : true
+physics.analyzers.TrkAnaNeg.FillCRV : true
 physics.analyzers.TrkAnaNeg.FillTriggerInfo : true
 physics.analyzers.TrkAnaPos.diagLevel : 1
 physics.analyzers.TrkAnaPos.FillMCInfo : true
-physics.analyzers.TrkAnaPos.AnalyzeCRV : true
+physics.analyzers.TrkAnaPos.FillCRV : true
 physics.analyzers.TrkAnaPos.FillTriggerInfo : true
 
 services.TFileService.fileName: "nts.owner.trkana-reco.version.sequencer.root"

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -145,9 +145,9 @@ TrkAnaTreeMaker : {
   FillTriggerInfo : true
   TriggerProcessName : "Mix"
   ProcessEmptyEvents : false
-  AnalyzeCRV : true
-  AnalyzeCRVHits : false
-  AnalyzeCRVPulses : false
+  FillCRV : true
+  FillCRVHits : false
+  FillCRVPulses : false
   PrimaryParticleTag : "compressRecoMCs"
   KalSeedMCAssns : "SelectRecoMC"
   CaloClusterMCTag : "compressRecoMCs"

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -146,6 +146,7 @@ TrkAnaTreeMaker : {
   TriggerProcessName : "Mix"
   ProcessEmptyEvents : false
   AnalyzeCRV : true
+  AnalyzeCRVHits : false
   AnalyzeCRVPulses : false
   PrimaryParticleTag : "compressRecoMCs"
   KalSeedMCAssns : "SelectRecoMC"

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -236,8 +236,17 @@ namespace mu2e {
     std::vector<art::Handle<EventWeight> > _wtHandles;
     EventWeightInfo _wtinfo;
     // CRV
-    // CRV -- fhicl parameter
+    // CRV -- fhicl parameters
+    bool _crv;
     bool _crvexpert;
+    bool _crvpulses;
+    std::string _crvCoincidenceModuleLabel;
+    std::string _crvCoincidenceMCModuleLabel;
+    std::string _crvRecoPulseLabel;
+    std::string _crvStepLabel;
+    std::string _crvWaveformsModuleLabel;
+    std::string _crvDigiModuleLabel;
+    double _crvPlaneY;
     // CRV -- other
     std::vector<CrvHitInfoReco> _crvinfo;
     int _bestcrv;
@@ -277,7 +286,18 @@ namespace mu2e {
     _PBTTag(conf().PBTTag()),
     _PBTMCTag(conf().PBTMCTag()),
     _trigbitsh(0),
+    // CRV
+    _crv(conf().crv()),
     _crvexpert(conf().crvexpert()),
+    _crvpulses(conf().crvpulses()),
+    _crvCoincidenceModuleLabel(conf().crvCoincidenceModuleLabel()),
+    _crvCoincidenceMCModuleLabel(conf().crvCoincidenceMCModuleLabel()),
+    _crvRecoPulseLabel(conf().crvRecoPulseLabel()),
+    _crvStepLabel(conf().crvStepLabel()),
+    _crvWaveformsModuleLabel(conf().crvWaveformsModuleLabel()),
+    _crvDigiModuleLabel(conf().crvDigiModuleLabel()),
+    _crvPlaneY(conf().crvPlaneY()),
+
     _infoMCStructHelper(conf().infoMCStructHelper()),
     _buffsize(conf().buffsize()),
     _splitlevel(conf().splitlevel())
@@ -417,21 +437,21 @@ namespace mu2e {
     }
 // calorimeter information for the downstream electron track
 // CRV info
-    if(_conf.crv()) {
+    if(_crv) {
       _trkana->Branch("crvinfo",&_crvinfo,_buffsize,_splitlevel);
       _trkana->Branch("crvsummary",&_crvsummary,_buffsize,_splitlevel);
       _trkana->Branch("bestcrv",&_bestcrv,_buffsize,_splitlevel);
-      if(_conf.crvpulses()) {
+      if(_crvpulses) {
         _trkana->Branch("crvpulseinfo",&_crvpulseinfo,_buffsize,_splitlevel);
         _trkana->Branch("crvwaveforminfo",&_crvwaveforminfo,_buffsize,_splitlevel);
       }
       if(_conf.fillmc()){
-        if(_conf.crv())
+        if(_crv)
         {
           _trkana->Branch("crvinfomc",&_crvinfomc,_buffsize,_splitlevel);
           _trkana->Branch("crvsummarymc",&_crvsummarymc,_buffsize,_splitlevel);
           _trkana->Branch("crvinfomcplane",&_crvinfomcplane,_buffsize,_splitlevel);
-          if(_conf.crvpulses())
+          if(_crvpulses)
             _trkana->Branch("crvpulseinfomc",&_crvpulseinfomc,_buffsize,_splitlevel);
         }
       }
@@ -599,15 +619,15 @@ namespace mu2e {
 
       // TODO we want MC information when we don't have a track
       // fill CRV info
-      if(_conf.crv()){
-        CRVAnalysis::FillCrvHitInfoCollections(_conf.crvCoincidenceModuleLabel(), _conf.crvCoincidenceMCModuleLabel(),
-                                               _conf.crvRecoPulseLabel(), _conf.crvStepLabel(), _conf.simParticleLabel(), _conf.mcTrajectoryLabel(), event,
-                                               _crvinfo, _crvinfomc, _crvsummary, _crvsummarymc, _crvinfomcplane, _conf.crvPlaneY());
-        if(_conf.crvpulses()){
+      if(_crv){
+        CRVAnalysis::FillCrvHitInfoCollections(_crvCoincidenceModuleLabel, _crvCoincidenceMCModuleLabel,
+                                               _crvRecoPulseLabel, _crvStepLabel, _conf.simParticleLabel(), _conf.mcTrajectoryLabel(), event,
+                                               _crvinfo, _crvinfomc, _crvsummary, _crvsummarymc, _crvinfomcplane, _crvPlaneY);
+        if(_crvpulses){
           // temporary hack: FIXME
           std::vector<art::InputTag> nulltags;
           SimParticleTimeOffset nulloffset(nulltags);
-          CRVAnalysis::FillCrvPulseInfoCollections(_conf.crvRecoPulseLabel(), _conf.crvWaveformsModuleLabel(), _conf.crvDigiModuleLabel(),
+          CRVAnalysis::FillCrvPulseInfoCollections(_crvRecoPulseLabel, _crvWaveformsModuleLabel, _crvDigiModuleLabel,
                                                    nulloffset, event, _crvpulseinfo, _crvpulseinfomc, _crvwaveforminfo);
         }
 

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -249,7 +249,7 @@ namespace mu2e {
     double _crvPlaneY;
     // CRV -- other
     std::vector<CrvHitInfoReco> _crvinfo;
-    int _bestcrv;
+    CrvHitInfoReco _bestcrv;
     std::vector<CrvHitInfoMC> _crvinfomc;
     CrvSummaryReco _crvsummary;
     CrvSummaryMC   _crvsummarymc;
@@ -634,7 +634,7 @@ namespace mu2e {
         }
 
 //      find the best CRV match (closest in time)
-        _bestcrv=-1;
+        int ibestcrv=-1;
         float mindt=1.0e9;
         float t0 = candidateKS.t0().t0();
         for(size_t icrv=0;icrv< _crvinfo.size(); ++icrv){
@@ -642,9 +642,12 @@ namespace mu2e {
           float dt = std::min(fabs(crvinfo._timeWindowStart-t0), fabs(crvinfo._timeWindowEnd-t0) );
           if(dt < mindt){
             mindt =dt;
-            _bestcrv = icrv;
+            ibestcrv = icrv;
           }
         }
+	if (ibestcrv>=0) {
+	  _bestcrv = _crvinfo.at(ibestcrv);
+	}
       }
       // fill this row in the TTree
       _trkana->Fill();

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -931,6 +931,8 @@ namespace mu2e {
       _allTSHIMCs.at(i_branch).clear();
     }
 // clear vectors
+    _bestcrv = CrvHitInfoReco();
+    _bestcrvmc = CrvHitInfoMC();
     _crvinfo.clear();
     _crvinfomc.clear();
     _crvinfomcplane.clear();

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -129,19 +129,26 @@ namespace mu2e {
       fhicl::Atom<art::InputTag> PBTTag{Name("PBTTag"), Comment("Tag for ProtonBunchTime object") ,art::InputTag()};
       fhicl::Atom<art::InputTag> PBTMCTag{Name("PBTMCTag"), Comment("Tag for ProtonBunchTimeMC object") ,art::InputTag()};
       fhicl::Atom<art::InputTag> caloClusterMCTag{Name("CaloClusterMCTag"), Comment("Tag for CaloClusterMCCollection") ,art::InputTag()};
+      fhicl::Atom<std::string> simParticleLabel{Name("SimParticleLabel"), Comment("SimParticleLabel")};
+      fhicl::Atom<std::string> mcTrajectoryLabel{Name("MCTrajectoryLabel"), Comment("MCTrajectoryLabel")};
+      fhicl::Atom<bool> fillmc{Name("FillMCInfo"),Comment("Global switch to turn on/off MC info"),true};
+      fhicl::Atom<bool> pempty{Name("ProcessEmptyEvents"),false};
+
+      // CRV -- flags
+      fhicl::Atom<bool> crv{Name("AnalyzeCRV"),false};
+      fhicl::Atom<bool> crvexpert{Name("crvexpert"), Comment("Flag for turning on branches for CRV experts"), false};
+      fhicl::Atom<bool> crvpulses{Name("AnalyzeCRVPulses"),false};
+      // CRV -- input tags
       fhicl::Atom<std::string> crvCoincidenceModuleLabel{Name("CrvCoincidenceModuleLabel"), Comment("CrvCoincidenceModuleLabel")};
       fhicl::Atom<std::string> crvCoincidenceMCModuleLabel{Name("CrvCoincidenceMCModuleLabel"), Comment("CrvCoincidenceMCModuleLabel")};
       fhicl::Atom<std::string> crvRecoPulseLabel{Name("CrvRecoPulseLabel"), Comment("CrvRecoPulseLabel")};
       fhicl::Atom<std::string> crvStepLabel{Name("CrvStepLabel"), Comment("CrvStepLabel")};
-      fhicl::Atom<std::string> simParticleLabel{Name("SimParticleLabel"), Comment("SimParticleLabel")};
-      fhicl::Atom<std::string> mcTrajectoryLabel{Name("MCTrajectoryLabel"), Comment("MCTrajectoryLabel")};
-      fhicl::Atom<double> crvPlaneY{Name("CrvPlaneY"),2751.485};  //y of center of the top layer of the CRV-T counters
       fhicl::Atom<std::string> crvWaveformsModuleLabel{ Name("CrvWaveformsModuleLabel"), Comment("CrvWaveformsModuleLabel")};
       fhicl::Atom<std::string> crvDigiModuleLabel{ Name("CrvDigiModuleLabel"), Comment("CrvDigiModuleLabel")};
-      fhicl::Atom<bool> fillmc{Name("FillMCInfo"),Comment("Global switch to turn on/off MC info"),true};
-      fhicl::Atom<bool> pempty{Name("ProcessEmptyEvents"),false};
-      fhicl::Atom<bool> crv{Name("AnalyzeCRV"),false};
-      fhicl::Atom<bool> crvpulses{Name("AnalyzeCRVPulses"),false};
+      // CRV -- other
+      fhicl::Atom<double> crvPlaneY{Name("CrvPlaneY"),2751.485};  //y of center of the top layer of the CRV-T counters
+
+
       fhicl::Atom<bool> helices{Name("FillHelixInfo"),false};
       fhicl::Atom<bool> filltrkqual{Name("FillTrkQualInfo"),false};
       fhicl::Atom<bool> filltrkpid{Name("FillTrkPIDInfo"),false};
@@ -228,7 +235,10 @@ namespace mu2e {
     // event weights
     std::vector<art::Handle<EventWeight> > _wtHandles;
     EventWeightInfo _wtinfo;
-    // CRV info
+    // CRV
+    // CRV -- fhicl parameter
+    bool _crvexpert;
+    // CRV -- other
     std::vector<CrvHitInfoReco> _crvinfo;
     int _bestcrv;
     std::vector<CrvHitInfoMC> _crvinfomc;
@@ -238,6 +248,7 @@ namespace mu2e {
     std::vector<CrvPulseInfoReco> _crvpulseinfo;
     std::vector<CrvWaveformInfo> _crvwaveforminfo;
     std::vector<CrvHitInfoMC> _crvpulseinfomc;
+
     // helices
     HelixInfo _hinfo;
     // struct helpers
@@ -266,6 +277,7 @@ namespace mu2e {
     _PBTTag(conf().PBTTag()),
     _PBTMCTag(conf().PBTMCTag()),
     _trigbitsh(0),
+    _crvexpert(conf().crvexpert()),
     _infoMCStructHelper(conf().infoMCStructHelper()),
     _buffsize(conf().buffsize()),
     _splitlevel(conf().splitlevel())

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -439,9 +439,9 @@ namespace mu2e {
 // calorimeter information for the downstream electron track
 // CRV info
     if(_crv) {
-      _trkana->Branch("crvsummary",&_crvsummary,_buffsize,_splitlevel);
       _trkana->Branch("bestcrv",&_bestcrv,_buffsize,_splitlevel);
       if (_crvexpert) {
+	_trkana->Branch("crvsummary",&_crvsummary,_buffsize,_splitlevel);
 	_trkana->Branch("crvinfo",&_crvinfo,_buffsize,_splitlevel);
 	if(_crvpulses) {
 	  _trkana->Branch("crvpulseinfo",&_crvpulseinfo,_buffsize,_splitlevel);
@@ -449,9 +449,9 @@ namespace mu2e {
 	}
       }
       if(_conf.fillmc()){
-	_trkana->Branch("crvsummarymc",&_crvsummarymc,_buffsize,_splitlevel);
 	_trkana->Branch("bestcrvmc",&_bestcrvmc,_buffsize,_splitlevel);
 	if (_crvexpert) {
+	  _trkana->Branch("crvsummarymc",&_crvsummarymc,_buffsize,_splitlevel);
 	  _trkana->Branch("crvinfomc",&_crvinfomc,_buffsize,_splitlevel);
 	  _trkana->Branch("crvinfomcplane",&_crvinfomcplane,_buffsize,_splitlevel);
 	  if(_crvpulses) {

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -135,9 +135,9 @@ namespace mu2e {
       fhicl::Atom<bool> pempty{Name("ProcessEmptyEvents"),false};
 
       // CRV -- flags
-      fhicl::Atom<bool> crv{Name("AnalyzeCRV"),Comment("Flag for turning on bestcrv(mc) branches"), false};
-      fhicl::Atom<bool> crvhits{Name("AnalyzeCRVHits"), Comment("Flag for turning on crvinfo(mc), crvsummary(mc), and crvinfomcplane branches"), false};
-	fhicl::Atom<bool> crvpulses{Name("AnalyzeCRVPulses"),Comment("Flag for turning on crvpulseinfo(mc), crvwaveforminfo branches"), false};
+      fhicl::Atom<bool> crv{Name("FillCRV"),Comment("Flag for turning on bestcrv(mc) branches"), false};
+      fhicl::Atom<bool> crvhits{Name("FillCRVHits"), Comment("Flag for turning on crvinfo(mc), crvsummary(mc), and crvinfomcplane branches"), false};
+	fhicl::Atom<bool> crvpulses{Name("FillCRVPulses"),Comment("Flag for turning on crvpulseinfo(mc), crvwaveforminfo branches"), false};
       // CRV -- input tags
       fhicl::Atom<std::string> crvCoincidenceModuleLabel{Name("CrvCoincidenceModuleLabel"), Comment("CrvCoincidenceModuleLabel")};
       fhicl::Atom<std::string> crvCoincidenceMCModuleLabel{Name("CrvCoincidenceMCModuleLabel"), Comment("CrvCoincidenceMCModuleLabel")};

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -438,22 +438,24 @@ namespace mu2e {
 // calorimeter information for the downstream electron track
 // CRV info
     if(_crv) {
-      _trkana->Branch("crvinfo",&_crvinfo,_buffsize,_splitlevel);
       _trkana->Branch("crvsummary",&_crvsummary,_buffsize,_splitlevel);
       _trkana->Branch("bestcrv",&_bestcrv,_buffsize,_splitlevel);
-      if(_crvpulses) {
-        _trkana->Branch("crvpulseinfo",&_crvpulseinfo,_buffsize,_splitlevel);
-        _trkana->Branch("crvwaveforminfo",&_crvwaveforminfo,_buffsize,_splitlevel);
+      if (_crvexpert) {
+	_trkana->Branch("crvinfo",&_crvinfo,_buffsize,_splitlevel);
+	if(_crvpulses) {
+	  _trkana->Branch("crvpulseinfo",&_crvpulseinfo,_buffsize,_splitlevel);
+	  _trkana->Branch("crvwaveforminfo",&_crvwaveforminfo,_buffsize,_splitlevel);
+	}
       }
       if(_conf.fillmc()){
-        if(_crv)
-        {
-          _trkana->Branch("crvinfomc",&_crvinfomc,_buffsize,_splitlevel);
-          _trkana->Branch("crvsummarymc",&_crvsummarymc,_buffsize,_splitlevel);
-          _trkana->Branch("crvinfomcplane",&_crvinfomcplane,_buffsize,_splitlevel);
-          if(_crvpulses)
-            _trkana->Branch("crvpulseinfomc",&_crvpulseinfomc,_buffsize,_splitlevel);
-        }
+	_trkana->Branch("crvsummarymc",&_crvsummarymc,_buffsize,_splitlevel);
+	if (_crvexpert) {
+	  _trkana->Branch("crvinfomc",&_crvinfomc,_buffsize,_splitlevel);
+	  _trkana->Branch("crvinfomcplane",&_crvinfomcplane,_buffsize,_splitlevel);
+	  if(_crvpulses) {
+	    _trkana->Branch("crvpulseinfomc",&_crvpulseinfomc,_buffsize,_splitlevel);
+	  }
+	}
       }
     }
 // helix info

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -136,7 +136,7 @@ namespace mu2e {
 
       // CRV -- flags
       fhicl::Atom<bool> crv{Name("AnalyzeCRV"),false};
-      fhicl::Atom<bool> crvexpert{Name("crvexpert"), Comment("Flag for turning on branches for CRV experts"), false};
+      fhicl::Atom<bool> crvhits{Name("AnalyzeCRVHits"), Comment("Flag for turning on crvinfo branches"), false};
       fhicl::Atom<bool> crvpulses{Name("AnalyzeCRVPulses"),false};
       // CRV -- input tags
       fhicl::Atom<std::string> crvCoincidenceModuleLabel{Name("CrvCoincidenceModuleLabel"), Comment("CrvCoincidenceModuleLabel")};
@@ -238,7 +238,7 @@ namespace mu2e {
     // CRV
     // CRV -- fhicl parameters
     bool _crv;
-    bool _crvexpert;
+    bool _crvhits;
     bool _crvpulses;
     std::string _crvCoincidenceModuleLabel;
     std::string _crvCoincidenceMCModuleLabel;
@@ -289,7 +289,7 @@ namespace mu2e {
     _trigbitsh(0),
     // CRV
     _crv(conf().crv()),
-    _crvexpert(conf().crvexpert()),
+    _crvhits(conf().crvhits()),
     _crvpulses(conf().crvpulses()),
     _crvCoincidenceModuleLabel(conf().crvCoincidenceModuleLabel()),
     _crvCoincidenceMCModuleLabel(conf().crvCoincidenceMCModuleLabel()),
@@ -440,7 +440,7 @@ namespace mu2e {
 // CRV info
     if(_crv) {
       _trkana->Branch("bestcrv",&_bestcrv,_buffsize,_splitlevel);
-      if (_crvexpert) {
+      if (_crvhits) {
 	_trkana->Branch("crvsummary",&_crvsummary,_buffsize,_splitlevel);
 	_trkana->Branch("crvinfo",&_crvinfo,_buffsize,_splitlevel);
 	if(_crvpulses) {
@@ -450,7 +450,7 @@ namespace mu2e {
       }
       if(_conf.fillmc()){
 	_trkana->Branch("bestcrvmc",&_bestcrvmc,_buffsize,_splitlevel);
-	if (_crvexpert) {
+	if (_crvhits) {
 	  _trkana->Branch("crvsummarymc",&_crvsummarymc,_buffsize,_splitlevel);
 	  _trkana->Branch("crvinfomc",&_crvinfomc,_buffsize,_splitlevel);
 	  _trkana->Branch("crvinfomcplane",&_crvinfomcplane,_buffsize,_splitlevel);

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -135,9 +135,9 @@ namespace mu2e {
       fhicl::Atom<bool> pempty{Name("ProcessEmptyEvents"),false};
 
       // CRV -- flags
-      fhicl::Atom<bool> crv{Name("AnalyzeCRV"),false};
-      fhicl::Atom<bool> crvhits{Name("AnalyzeCRVHits"), Comment("Flag for turning on crvinfo branches"), false};
-      fhicl::Atom<bool> crvpulses{Name("AnalyzeCRVPulses"),false};
+      fhicl::Atom<bool> crv{Name("AnalyzeCRV"),Comment("Flag for turning on bestcrv(mc) branches"), false};
+      fhicl::Atom<bool> crvhits{Name("AnalyzeCRVHits"), Comment("Flag for turning on crvinfo(mc), crvsummary(mc), and crvinfomcplane branches"), false};
+	fhicl::Atom<bool> crvpulses{Name("AnalyzeCRVPulses"),Comment("Flag for turning on crvpulseinfo(mc), crvwaveforminfo branches"), false};
       // CRV -- input tags
       fhicl::Atom<std::string> crvCoincidenceModuleLabel{Name("CrvCoincidenceModuleLabel"), Comment("CrvCoincidenceModuleLabel")};
       fhicl::Atom<std::string> crvCoincidenceMCModuleLabel{Name("CrvCoincidenceMCModuleLabel"), Comment("CrvCoincidenceMCModuleLabel")};

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -251,6 +251,7 @@ namespace mu2e {
     std::vector<CrvHitInfoReco> _crvinfo;
     CrvHitInfoReco _bestcrv;
     std::vector<CrvHitInfoMC> _crvinfomc;
+    CrvHitInfoMC _bestcrvmc;
     CrvSummaryReco _crvsummary;
     CrvSummaryMC   _crvsummarymc;
     std::vector<CrvPlaneInfoMC> _crvinfomcplane;
@@ -449,6 +450,7 @@ namespace mu2e {
       }
       if(_conf.fillmc()){
 	_trkana->Branch("crvsummarymc",&_crvsummarymc,_buffsize,_splitlevel);
+	_trkana->Branch("bestcrvmc",&_bestcrvmc,_buffsize,_splitlevel);
 	if (_crvexpert) {
 	  _trkana->Branch("crvinfomc",&_crvinfomc,_buffsize,_splitlevel);
 	  _trkana->Branch("crvinfomcplane",&_crvinfomcplane,_buffsize,_splitlevel);
@@ -647,6 +649,7 @@ namespace mu2e {
         }
 	if (ibestcrv>=0) {
 	  _bestcrv = _crvinfo.at(ibestcrv);
+	  _bestcrvmc = _crvinfomc.at(ibestcrv);
 	}
       }
       // fill this row in the TTree


### PR DESCRIPTION
This PR makes some changes to the CRV-related branches in TrkAna. 

List of changes:
 - branches ```crvinfo```, ```crvinfomc```, ```crvsummary```, ```crvummarymc```, and ```crvinfomcplane``` are now hidden behind ```FillCRVHits``` fhicl parameter
   - these are now turned off by default in TrkAnaReco.fcl
   -  new CrvExpert.fcl shows how to generate these branches
 - ```bestcrv``` branch is no longer an integer corresponding to an element in the ```crvinfo``` array but a ```CrvInfoReco``` struct
   - i.e. ROOT cut ```crvinfo[bestcrv]._timeWindowStart>-80``` is now ```bestcrv._timeWindowStart>-80```
 - new ```bestcrvmc``` branch contains the ```CrvInfoMC``` equivalent information
 - fhicl parameters ```AnalyzerCRV*``` have been renamed to ```FillCRV*``` for consistency with other fhicl parameters in TrkAna
 - started moving away from having ```Config _conf``` member variable to store all fhicl parameters