### PR TITLE
Remove Helix Parameters

### DIFF
--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -16,8 +16,11 @@ namespace mu2e
     XYZVectorF mom;
     XYZVectorF pos;
     Float_t momerr;
+    Float_t d0;
+    Float_t maxr;
+    Float_t td;
     TrkFitInfo() { reset(); }
-    void reset() {mom= XYZVectorF(); pos=XYZVectorF(); momerr=-1000.0; }
+    void reset() {mom= XYZVectorF(); pos=XYZVectorF(); momerr=-1000.0; d0=0.0; maxr=0.0; td = 0.0; }
   };
 
   // general information about a track

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -7,7 +7,6 @@
 #ifndef TrkInfo_HH
 #define TrkInfo_HH
 #include "Offline/DataProducts/inc/GenVector.hh"
-#include "TrkAna/inc/helixpar.hh"
 #include "Offline/MCDataProducts/inc/MCRelationship.hh"
 #include "Rtypes.h"
 namespace mu2e
@@ -17,11 +16,8 @@ namespace mu2e
     XYZVectorF mom;
     XYZVectorF pos;
     Float_t momerr;
-    // helix parameters are deprecated FIXME!
-    helixpar fitpar;
-    helixpar fitparerr;
     TrkFitInfo() { reset(); }
-    void reset() {mom= XYZVectorF(); momerr=-1000.0; fitpar.reset(); fitparerr.reset(); }
+    void reset() {mom= XYZVectorF(); momerr=-1000.0; }
   };
 
   // general information about a track
@@ -76,11 +72,10 @@ namespace mu2e
   //  MC information about a particle for a specific point/time
   struct TrkInfoMCStep {
     Float_t time;  // time of this step
-    helixpar hpar; // helix parameters corresponding to the particle position and momentum assuming the nominal BField
     XYZVectorF mom; // particle momentum at the start of this step
     XYZVectorF pos;  // particle position at the start of this step
     TrkInfoMCStep() { reset(); }
-    void reset() { time = -1; mom = XYZVectorF(); pos = XYZVectorF(); hpar.reset(); }
+    void reset() { time = -1; mom = XYZVectorF(); pos = XYZVectorF(); }
   };
 
 }

--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -17,7 +17,7 @@ namespace mu2e
     XYZVectorF pos;
     Float_t momerr;
     TrkFitInfo() { reset(); }
-    void reset() {mom= XYZVectorF(); momerr=-1000.0; }
+    void reset() {mom= XYZVectorF(); pos=XYZVectorF(); momerr=-1000.0; }
   };
 
   // general information about a track

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -15,7 +15,6 @@
 #include "Offline/GlobalConstantsService/inc/ParticleDataList.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
-#include "Offline/BFieldGeom/inc/BFieldManager.hh"
 
 #include <map>
 #include <limits>
@@ -157,11 +156,9 @@ namespace mu2e {
   void InfoMCStructHelper::fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep,
       std::vector<int> const& vids, double target_time) {
 
-    GeomHandle<BFieldManager> bfmgr;
     GeomHandle<DetectorSystem> det;
     GlobalConstantsHandle<ParticleDataList> pdt;
     static CLHEP::Hep3Vector vpoint_mu2e = det->toMu2e(CLHEP::Hep3Vector(0.0,0.0,0.0));
-    static double bz = bfmgr->getBField(vpoint_mu2e).z();
 
     const auto& mcsteps = kseedmc._vdsteps;
     double dmin = std::numeric_limits<double>::max();
@@ -176,15 +173,6 @@ namespace mu2e {
             trkinfomcstep.time = i_mcstep._time;
             trkinfomcstep.mom = XYZVectorF(i_mcstep._mom);
             trkinfomcstep.pos = XYZVectorF(i_mcstep._pos);
-
-            // the following is obsolete and should be replaced or removed FIXME!
-            CLHEP::HepVector parvec(5,0);
-            double hflt(0.0);
-            HepPoint ppos(trkinfomcstep.pos.x(), trkinfomcstep.pos.y(), trkinfomcstep.pos.z());
-            CLHEP::Hep3Vector mom = GenVector::Hep3Vec(i_mcstep._mom);
-            double charge = pdt->particle(kseedmc.simParticle()._pdg).charge();
-            TrkHelixUtils::helixFromMom( parvec, hflt,ppos, mom,charge,bz);
-            trkinfomcstep.hpar = helixpar(parvec);
           }
         }
       }

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -4,7 +4,7 @@
 //
 #include "TrkAna/inc/InfoStructHelper.hh"
 #include "Offline/RecoDataProducts/inc/TrkStrawHitSeed.hh"
-
+#include "KinKal/Trajectory/CentralHelix.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include <cmath>
 
@@ -94,6 +94,9 @@ namespace mu2e {
     trkfitinfo.mom = ksegIter->momentum3();
     trkfitinfo.pos = ksegIter->position3();
     trkfitinfo.momerr = ksegIter->momerr();
+    trkfitinfo.d0 = ksegIter->centralHelix().d0();
+    trkfitinfo.maxr = ksegIter->centralHelix().d0() + 2.0/ksegIter->centralHelix().omega();
+    trkfitinfo.td = ksegIter->centralHelix().tanDip();
   }
 
   void InfoStructHelper::fillTrkInfoHits(const KalSeed& kseed, TrkInfo& trkinfo) {

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -94,10 +94,6 @@ namespace mu2e {
     trkfitinfo.mom = ksegIter->momentum3();
     trkfitinfo.pos = ksegIter->position3();
     trkfitinfo.momerr = ksegIter->momerr();
-    trkfitinfo.fitpar = ksegIter->helix();
-    CLHEP::HepSymMatrix pcov;
-    ksegIter->covar().symMatrix(pcov);
-    trkfitinfo.fitparerr = helixpar(pcov);
   }
 
   void InfoStructHelper::fillTrkInfoHits(const KalSeed& kseed, TrkInfo& trkinfo) {

--- a/src/SConscript
+++ b/src/SConscript
@@ -30,7 +30,8 @@ mainlib = helper.make_mainlib ( [
     'mu2e_MCDataProducts',
     'mu2e_RecoDataProducts',
     'mu2e_CalorimeterGeom',
-    'General'
+    'General',
+    'Trajectory'
 ] )
 
 # Fixme: split into link lists for each module.


### PR DESCRIPTION
Hi Everyone. This PR removes the helix parameterizations from the TrkAna trees. The leaves used from these branches have been stand-ins for things like cosmic-ray rejection based on track extrapolation. For the time being I have kept individual leaves for ```d0```, ```td```, and ```maxr``` while we implement a module that performs such algorithms.