### PR TITLE
Nicer Python Interface + BestCRV bug fix

### DIFF
--- a/inc/EventWeightInfo.hh
+++ b/inc/EventWeightInfo.hh
@@ -10,13 +10,10 @@ namespace mu2e
 {
   struct EventWeightInfo {
     static const int MAX_WEIGHTS = 50;
-    const std::string leafnames(std::vector<std::string> labels) {
-      std::string leaves = "nwts/I:";
+    const std::vector<std::string> leafnames(std::vector<std::string> labels) {
+      std::vector<std::string> leaves;
       for (std::vector<std::string>::const_iterator i_label = labels.begin(); i_label != labels.end(); ++i_label) {
-        leaves += *i_label + "/F";
-        if (i_label != labels.end()-1) {
-          leaves += ":";
-        }
+        leaves.push_back(*i_label);
       }
       n_weights = labels.size();
       return leaves;

--- a/inc/EventWeightInfo.hh
+++ b/inc/EventWeightInfo.hh
@@ -10,6 +10,18 @@ namespace mu2e
 {
   struct EventWeightInfo {
     static const int MAX_WEIGHTS = 50;
+    const std::string leafname(std::vector<std::string> labels) {
+      std::string leaves = "nwts/I:";
+      for (std::vector<std::string>::const_iterator i_label = labels.begin(); i_label != labels.end(); ++i_label) {
+        leaves += *i_label + "/F";
+        if (i_label != labels.end()-1) {
+          leaves += ":";
+        }
+      }
+      n_weights = labels.size();
+      return leaves;
+    }
+
     const std::vector<std::string> leafnames(std::vector<std::string> labels) {
       std::vector<std::string> leaves;
       for (std::vector<std::string>::const_iterator i_label = labels.begin(); i_label != labels.end(); ++i_label) {

--- a/inc/RecoQualInfo.hh
+++ b/inc/RecoQualInfo.hh
@@ -10,13 +10,11 @@ namespace mu2e
 {
   struct RecoQualInfo {
     static const int MAX_QUALS = 50;
-    const std::string leafnames(std::vector<std::string> labels) {
-      std::string leaves = "nquals/I:";
+    const std::vector<std::string> leafnames(std::vector<std::string> labels) {
+      std::vector<std::string> leaves;
       for (std::vector<std::string>::const_iterator i_label = labels.begin(); i_label != labels.end(); ++i_label) {
-        leaves += *i_label + "/F:" + *i_label + "Calib/F";
-        if (i_label != labels.end()-1) {
-          leaves += ":";
-        }
+        leaves.push_back(*i_label);
+        leaves.push_back((*i_label)+"Calib");
       }
       n_quals = labels.size()*2;
       return leaves;

--- a/inc/RecoQualInfo.hh
+++ b/inc/RecoQualInfo.hh
@@ -10,6 +10,18 @@ namespace mu2e
 {
   struct RecoQualInfo {
     static const int MAX_QUALS = 50;
+    const std::string leafname(std::vector<std::string> labels) {
+      std::string leaves = "nquals/I:";
+      for (std::vector<std::string>::const_iterator i_label = labels.begin(); i_label != labels.end(); ++i_label) {
+        leaves += *i_label + "/F:" + *i_label + "Calib/F";
+        if (i_label != labels.end()-1) {
+          leaves += ":";
+        }
+      }
+      n_quals = labels.size()*2;
+      return leaves;
+    }
+
     const std::vector<std::string> leafnames(std::vector<std::string> labels) {
       std::vector<std::string> leaves;
       for (std::vector<std::string>::const_iterator i_label = labels.begin(); i_label != labels.end(); ++i_label) {

--- a/src/BestCrvHitDeltaT_module.cc
+++ b/src/BestCrvHitDeltaT_module.cc
@@ -82,7 +82,7 @@ namespace mu2e {
         const auto& crvCoinc = crvCoincidenceHandle->at(i_crvCoinc);
         auto const& crvStartTime = crvCoinc.GetStartTime();
         auto const& crvEndTime = crvCoinc.GetEndTime();
-        float dt = std::min(fabs(crvStartTime-t0), fabs(crvEndTime-t0) );
+        float dt = fabs(crvStartTime-t0);
         if(dt < mindt){
           mindt = dt;
           i_bestCrvCoinc = i_crvCoinc;

--- a/src/BestCrvHitDeltaT_module.cc
+++ b/src/BestCrvHitDeltaT_module.cc
@@ -56,7 +56,7 @@ namespace mu2e {
     art::EDProducer(conf),
     _kalSeedTag(conf().kalSeedTag()),
     _crvCoincidenceTag(conf().crvCoincidenceTag())
-  {  
+  {
     produces<BestCrvAssns>("first");
     produces<BestCrvAssns>("second");
   }
@@ -79,28 +79,28 @@ namespace mu2e {
       float min2dt=1.0e9;
       float t0 = kalSeed.t0().t0();
       for(size_t i_crvCoinc = 0; i_crvCoinc != nCrvCoincidences; ++i_crvCoinc) {
-	const auto& crvCoinc = crvCoincidenceHandle->at(i_crvCoinc);
-	auto const& crvStartTime = crvCoinc.GetStartTime();
-	auto const& crvEndTime = crvCoinc.GetEndTime();
-	float dt = std::min(fabs(crvStartTime-t0), fabs(crvEndTime-t0) );
-	if(dt < mindt){
-	  mindt = dt;
-	  i_bestCrvCoinc = i_crvCoinc;
-	}
-	else if (dt < min2dt) {
-	  min2dt = dt;
-	  i_secondBestCrvCoinc = i_crvCoinc;
-	}
+        const auto& crvCoinc = crvCoincidenceHandle->at(i_crvCoinc);
+        auto const& crvStartTime = crvCoinc.GetStartTime();
+        auto const& crvEndTime = crvCoinc.GetEndTime();
+        float dt = std::min(fabs(crvStartTime-t0), fabs(crvEndTime-t0) );
+        if(dt < mindt){
+          mindt = dt;
+          i_bestCrvCoinc = i_crvCoinc;
+        }
+        else if (dt < min2dt) {
+          min2dt = dt;
+          i_secondBestCrvCoinc = i_crvCoinc;
+        }
       }
       if (i_bestCrvCoinc!=nCrvCoincidences) {
-	auto kalSeedPtr = art::Ptr<KalSeed>(kalSeedHandle, i_kalSeed);
-	auto crvCoincPtr = art::Ptr<CrvCoincidenceCluster>(crvCoincidenceHandle, i_bestCrvCoinc);
-	firstAssns->addSingle(kalSeedPtr, crvCoincPtr);
+        auto kalSeedPtr = art::Ptr<KalSeed>(kalSeedHandle, i_kalSeed);
+        auto crvCoincPtr = art::Ptr<CrvCoincidenceCluster>(crvCoincidenceHandle, i_bestCrvCoinc);
+        firstAssns->addSingle(kalSeedPtr, crvCoincPtr);
       }
       if (i_secondBestCrvCoinc!=nCrvCoincidences) {
-	auto kalSeedPtr = art::Ptr<KalSeed>(kalSeedHandle, i_kalSeed);
-	auto crvCoincPtr = art::Ptr<CrvCoincidenceCluster>(crvCoincidenceHandle, i_secondBestCrvCoinc);
-	secondAssns->addSingle(kalSeedPtr, crvCoincPtr);
+        auto kalSeedPtr = art::Ptr<KalSeed>(kalSeedHandle, i_kalSeed);
+        auto crvCoincPtr = art::Ptr<CrvCoincidenceCluster>(crvCoincidenceHandle, i_secondBestCrvCoinc);
+        secondAssns->addSingle(kalSeedPtr, crvCoincPtr);
       }
     }
     event.put(std::move(firstAssns), "first");

--- a/src/BestCrvHitDeltaT_module.cc
+++ b/src/BestCrvHitDeltaT_module.cc
@@ -81,7 +81,6 @@ namespace mu2e {
       for(size_t i_crvCoinc = 0; i_crvCoinc != nCrvCoincidences; ++i_crvCoinc) {
         const auto& crvCoinc = crvCoincidenceHandle->at(i_crvCoinc);
         auto const& crvStartTime = crvCoinc.GetStartTime();
-        auto const& crvEndTime = crvCoinc.GetEndTime();
         float dt = fabs(crvStartTime-t0);
         if(dt < mindt){
           mindt = dt;

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -402,7 +402,7 @@ namespace mu2e {
     _trkana->Branch("evtinfo.",&_einfo,_buffsize,_splitlevel);
     _trkana->Branch("evtinfomc.",&_einfomc,_buffsize,_splitlevel);
 // hit counting branch
-    _trkana->Branch("hcnt.",&_hcnt,HitCount::leafnames().c_str());
+    _trkana->Branch("hcnt.",&_hcnt);
 // track counting branch
     std::vector<std::string> trkcntleaves;
     for (const auto& i_branchConfig : _allBranches) {

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -286,9 +286,9 @@ namespace mu2e {
     size_t findSupplementTrack(KalSeedCollection const& kcol,KalSeed const& candidate, bool sameColl);
     void fillAllInfos(const art::Handle<KalSeedCollection>& ksch, BranchIndex i_branch, size_t i_kseed);
 
-    template <typename T, typename TI>
+    template <typename T, typename TI, typename TIA>
     std::vector<art::Handle<T> > createSpecialBranch(const art::Event& event, const std::string& branchname,
-                                                     std::vector<art::Handle<T> >& handles, TI& infostruct, const std::string& selection = "");
+                                                     std::vector<art::Handle<T> >& handles, TI& infostruct, TIA& array, const std::string& selection = "");
 
 };
 
@@ -537,7 +537,7 @@ namespace mu2e {
 
     // need to create and define the event weight branch here because we only now know the EventWeight creating modules that have been run through the Event
     std::vector<art::Handle<EventWeight> > eventWeightHandles;
-    _wtHandles = createSpecialBranch(event, "evtwt", eventWeightHandles, _wtinfo);
+    _wtHandles = createSpecialBranch(event, "evtwt", eventWeightHandles, _wtinfo, _wtinfo._weights);
 
     std::string process = _conf.trigProcessName();
     // Get the KalSeedCollections for both the candidate and all supplements
@@ -564,7 +564,7 @@ namespace mu2e {
       // also create the reco qual branches
       std::vector<art::Handle<RecoQualCollection> > recoQualCollHandles;
       std::vector<art::Handle<RecoQualCollection> > selectedRQCHs;
-      selectedRQCHs = createSpecialBranch(event, i_branchConfig.branch()+"qual.", recoQualCollHandles, _allRQIs.at(i_branch), i_branchConfig.suffix());
+      selectedRQCHs = createSpecialBranch(event, i_branchConfig.branch()+"qual", recoQualCollHandles, _allRQIs.at(i_branch), _allRQIs.at(i_branch)._qualsAndCalibs, i_branchConfig.suffix());
       for (const auto& i_selectedRQCH : selectedRQCHs) {
         if (i_selectedRQCH->size() != kalSeedCollHandle->size()) {
           throw cet::exception("TrkAna") << "Sizes of KalSeedCollection and this RecoQualCollection are inconsistent (" << kalSeedCollHandle->size() << " and " << i_selectedRQCH->size() << " respectively)";
@@ -946,10 +946,11 @@ namespace mu2e {
   }
 
   // some branches can't be made until the analyze() function because we want to write out all data products of a certain type
-  template <typename T, typename TI>
+  // these all have an underlying array where we want to name the individual elements in the array with different leaf names
+  template <typename T, typename TI, typename TIA>
   std::vector<art::Handle<T> >  TrkAnaTreeMaker::createSpecialBranch(const art::Event& event, const std::string& branchname,
                                                                      std::vector<art::Handle<T> >& handles, // this parameter is only needed so that the template parameter T can be deduced. There is probably a better way to do this FIXME
-                                                                     TI& infostruct, const std::string& selection) {
+                                                                     TI& infostruct, TIA& array, const std::string& selection) {
     std::vector<art::Handle<T> > outputHandles;
     std::vector<art::Handle<T> > inputHandles = event.getMany<T>();
     if (inputHandles.size()>0) {
@@ -981,8 +982,13 @@ namespace mu2e {
         outputHandles.push_back(i_handle);
         labels.push_back(branchname);
       }
-      if (!_trkana->GetBranch(branchname.c_str())) {  // only want to create the branch once
-        _trkana->Branch((branchname+".").c_str(), &infostruct, infostruct.leafnames(labels).c_str());
+      const auto& leafnames = infostruct.leafnames(labels);
+      int n_leaves = leafnames.size();
+      for (int i_leaf = 0; i_leaf < n_leaves; ++i_leaf) {
+        std::string thisbranchname = (branchname+"."+leafnames.at(i_leaf));
+        if (!_trkana->GetBranch(thisbranchname.c_str())) {  // only want to create the branch once
+          _trkana->Branch(thisbranchname.c_str(), &array[i_leaf]);
+        }
       }
     }
     return outputHandles;

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -403,12 +403,12 @@ namespace mu2e {
     _trkana->Branch("evtinfomc.",&_einfomc,_buffsize,_splitlevel);
 // hit counting branch
     _trkana->Branch("hcnt.",&_hcnt);
-// track counting branch
-    std::vector<std::string> trkcntleaves;
-    for (const auto& i_branchConfig : _allBranches) {
-      trkcntleaves.push_back(i_branchConfig.branch());
+// track counting branches
+    for (BranchIndex i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {
+      BranchConfig i_branchConfig = _allBranches.at(i_branch);
+      std::string leafname = i_branchConfig.branch();
+      _trkana->Branch(("tcnt.n"+leafname).c_str(),&_tcnt._counts[i_branch]);
     }
-    _trkana->Branch("tcnt.",&_tcnt,_tcnt.leafnames(trkcntleaves).c_str());
 
 // create all candidate and supplement branches
     for (BranchIndex i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -420,7 +420,14 @@ namespace mu2e {
       _trkana->Branch((branch+"xit.").c_str(),&_allXitTIs.at(i_branch));
       _trkana->Branch((branch+"tch.").c_str(),&_allTCHIs.at(i_branch));
       if (_conf.filltrkqual() && i_branchConfig.options().filltrkqual()) {
-        _trkana->Branch((branch+"trkqual.").c_str(), &_allTQIs.at(i_branch), TrkQualInfo::leafnames().c_str());
+        int n_trkqual_vars = TrkQual::n_vars;
+        for (int i_trkqual_var = 0; i_trkqual_var < n_trkqual_vars; ++i_trkqual_var) {
+          TrkQual::MVA_varindex i_index =TrkQual::MVA_varindex(i_trkqual_var);
+          std::string varname = TrkQual::varName(i_index);
+          _trkana->Branch((branch+"trkqual."+varname).c_str(), &_allTQIs.at(i_branch)._trkqualvars[i_index]);
+        }
+        _trkana->Branch((branch+"trkqual.mvaout").c_str(), &_allTQIs.at(i_branch)._mvaout);
+        _trkana->Branch((branch+"trkqual.mvastat").c_str(), &_allTQIs.at(i_branch)._mvastat);
       }
       if (_conf.filltrkpid() && i_branchConfig.options().filltrkpid()) {
         _trkana->Branch((branch+"trkpid.").c_str(), &_allTPIs.at(i_branch), TrkPIDInfo::leafnames().c_str());

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -437,9 +437,9 @@ namespace mu2e {
         if (i_branchConfig.options().bestCrvBranches(bestCrvBranchNames)) {
           for (size_t i_bestCrvBranch = 0; i_bestCrvBranch < bestCrvBranchNames.size(); ++i_bestCrvBranch) {
             std::string bestCrvBranchName = bestCrvBranchNames.at(i_bestCrvBranch);
-            _trkana->Branch((branch+bestCrvBranchName).c_str(),&_allBestCrvs.at(i_branch).at(i_bestCrvBranch),_buffsize,_splitlevel);
+            _trkana->Branch((branch+bestCrvBranchName+".").c_str(),&_allBestCrvs.at(i_branch).at(i_bestCrvBranch),_buffsize,_splitlevel);
             if (_fillmc) {
-              _trkana->Branch((branch+bestCrvBranchName+"mc").c_str(),&_allBestCrvMCs.at(i_branch).at(i_bestCrvBranch),_buffsize,_splitlevel);
+              _trkana->Branch((branch+bestCrvBranchName+"mc.").c_str(),&_allBestCrvMCs.at(i_branch).at(i_bestCrvBranch),_buffsize,_splitlevel);
             }
           }
         }

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -430,7 +430,18 @@ namespace mu2e {
         _trkana->Branch((branch+"trkqual.mvastat").c_str(), &_allTQIs.at(i_branch)._mvastat);
       }
       if (_conf.filltrkpid() && i_branchConfig.options().filltrkpid()) {
-        _trkana->Branch((branch+"trkpid.").c_str(), &_allTPIs.at(i_branch), TrkPIDInfo::leafnames().c_str());
+        int n_trkpid_vars = TrkCaloHitPID::n_vars;
+        for (int i_trkpid_var = 0; i_trkpid_var < n_trkpid_vars; ++i_trkpid_var) {
+          TrkCaloHitPID::MVA_varindex i_index =TrkCaloHitPID::MVA_varindex(i_trkpid_var);
+          std::string varname = TrkCaloHitPID::varName(i_index);
+          _trkana->Branch((branch+"trkpid."+varname).c_str(), &_allTPIs.at(i_branch)._tchpvars[i_index]);
+        }
+        _trkana->Branch((branch+"trkpid.mvaout").c_str(), &_allTPIs.at(i_branch)._mvaout);
+        _trkana->Branch((branch+"trkpid.mvastat").c_str(), &_allTPIs.at(i_branch)._mvastat);
+        _trkana->Branch((branch+"trkpid.disk0frad").c_str(), &_allTPIs.at(i_branch)._diskfrad[0]);
+        _trkana->Branch((branch+"trkpid.disk1frad").c_str(), &_allTPIs.at(i_branch)._diskfrad[1]);
+        _trkana->Branch((branch+"trkpid.disk0brad").c_str(), &_allTPIs.at(i_branch)._diskbrad[0]);
+        _trkana->Branch((branch+"trkpid.disk1brad").c_str(), &_allTPIs.at(i_branch)._diskbrad[1]);
       }
       // optionally add hit-level branches
       // (for the time being diagLevel : 2 will still work, but I propose removing this at some point)

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -964,7 +964,7 @@ namespace mu2e {
         labels.push_back(branchname);
       }
       if (!_trkana->GetBranch(branchname.c_str())) {  // only want to create the branch once
-        _trkana->Branch(branchname.c_str(), &infostruct, infostruct.leafnames(labels).c_str());
+        _trkana->Branch((branchname+".").c_str(), &infostruct, infostruct.leafnames(labels).c_str());
       }
     }
     return outputHandles;


### PR DESCRIPTION
Hi Everyone,

This PR contains two changes. One is a simple bug fix in commit 70c74eb, as reported by the CRV group. The other is a continuation of PR #53, which resolves an issue when importing TrkAna trees to python. 

The issue is that branches like ```dequal.TrkQual``` gets imported as ```df["TrkQuals"]```, which would then clash with ```uequal.TrkQual```.

One complication with the branches fixed in this PR is that their leaf names are dynamic for flexibility. For example we want the ```evtwt``` branch to read out any ```EventWeight``` object created by the user. This means the solution in PR #53 (to put a period at the end of the branch name and let ROOT name the leaves) does not work here.

The solution I settled on is to create a new branch for each dynamic leaf. This fixes the issue in python and looks the same to ROOT scripts. However, one downside is that ```TrkAnaUtils::ListBranches()``` now lists all these "leaves" instead of the higher-level branch. I think this is OK for now but if we end up with a lot of these type of branches, we will defeat the purpose of TrkAnaUtils supplying a condensed list of branches.

Thanks,
Andy