### PR TITLE
Fix include paths for fcl files

### DIFF
--- a/fcl/TrkAnaRecoEnsemble-Data.fcl
+++ b/fcl/TrkAnaRecoEnsemble-Data.fcl
@@ -1,4 +1,4 @@
-#include "Offline/TrkDiag/fcl/TrkAnaReco.fcl"
+#include "TrkAna/fcl/TrkAnaReco.fcl"
 
 physics.analyzers.TrkAnaNeg.FillMCInfo : false
 physics.analyzers.TrkAnaPos.FillMCInfo : false

--- a/fcl/TrkAnaRecoEnsemble-MC.fcl
+++ b/fcl/TrkAnaRecoEnsemble-MC.fcl
@@ -1,4 +1,4 @@
-#include "Offline/TrkDiag/fcl/TrkAnaReco.fcl"
+#include "TrkAna/fcl/TrkAnaReco.fcl"
 
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequenceNoMC ]
 

--- a/fcl/TrkAnaReco_MultipleTrkQual.fcl
+++ b/fcl/TrkAnaReco_MultipleTrkQual.fcl
@@ -1,7 +1,6 @@
-#include "Offline/TrkDiag/fcl/TrkAnaReco.fcl"
+#include "TrkAna/fcl/TrkAnaReco.fcl"
 # Add another TrkQual module with a different training
 # (NB to be read out by TrkAna it must have the same suffix)
 physics.producers.TrkQualNewDeP : @local::TrkQualDeP
 physics.producers.TrkQualNewDeP.TrainingName : "TrkQualPosNew"
 physics.TrkAnaTrigPath : [ @sequence::TrkAnaReco.TrigSequence, TrkQualNewDeP ]
-

--- a/fcl/TrkAnaReco_Upstream.fcl
+++ b/fcl/TrkAnaReco_Upstream.fcl
@@ -1,4 +1,4 @@
-#include "Offline/TrkDiag/fcl/TrkAnaReco.fcl"
+#include "TrkAna/fcl/TrkAnaReco.fcl"
 
 process_name : TrkAnaRecoUpstream
 
@@ -7,4 +7,4 @@ physics.analyzers.TrkAnaNeg.supplements : [ @local::DeM, @local::UmuM ]
 physics.analyzers.TrkAnaPos.candidate : @local::UeP
 physics.analyzers.TrkAnaPos.supplements : [ @local::DeP, @local::UmuP ]
 
-services.TFileService.fileName: "nts.owner.trkana-reco.version.sequencer.root"
+services.TFileService.fileName: "nts.owner.trkana-reco-upstream.version.sequencer.root"

--- a/fcl/TrkAnaReco_addMCUpstream.fcl
+++ b/fcl/TrkAnaReco_addMCUpstream.fcl
@@ -1,0 +1,4 @@
+#include "TrkAna/fcl/TrkAnaReco.fcl"
+
+physics.analyzers.TrkAnaNeg.supplements[0].options : @local::AllOpt
+physics.analyzers.TrkAnaNeg.supplements[0].options.fillTrkPID : false

--- a/fcl/TrkAnaReco_wTrkQualFilter.fcl
+++ b/fcl/TrkAnaReco_wTrkQualFilter.fcl
@@ -1,7 +1,7 @@
 #include "Offline/fcl/minimalMessageService.fcl"
 #include "Offline/fcl/standardProducers.fcl"
 #include "Offline/fcl/standardServices.fcl"
-#include "Offline/TrkDiag/fcl/prolog.fcl"
+#include "TrkAna/fcl/prolog.fcl"
 
 process_name : TrkAnaReco
 


### PR DESCRIPTION
Some of the less-used fcl files have the old include paths. This PR fixes them all