### PR TITLE
Add ability to configure virtual detectors in TrkAna

### DIFF
--- a/fcl/TrkAnaReco_addStopTgtVDs.fcl
+++ b/fcl/TrkAnaReco_addStopTgtVDs.fcl
@@ -1,0 +1,19 @@
+// This fcl file gives an example of how an analyzer
+// can write a TrkAna tree with different VirtualDetectors
+//
+// This is useful if ....
+//
+// In this example, we will write branches for ST_Out virtual detector
+//
+
+// This example builds on TrkAnaReco.fcl
+#include "TrkAna/fcl/TrkAnaReco.fcl"
+
+// First define the suffix of the branches we want
+// In this example, "tgt" will mean we create branched "detgt", "demctgt", "uetgt", etc.
+physics.analyzers.TrkAnaNeg.candidate.segmentSuffixes : [ @sequence::physics.analyzers.TrkAnaNeg.candidate.segmentSuffixes, "tgt" ]
+
+// Then define the virtual detectors we want to be included in this branch
+// NB we add a sequence because we sometimes combine virtual detectors for one "interesting" plane
+// (e.g. TT_FrontHollow and TT_FrontPA define the entrance to the tracker)
+physics.analyzers.TrkAnaNeg.candidate.segmentVIDs : [ @sequence::physics.analyzers.TrkAnaNeg.candidate.segmentVIDs, ["ST_Out"] ]

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -133,6 +133,11 @@ dioLLWeight : {
 genCountLogger: { module_type: GenEventCountReader }
 
 # candidate configuration for TrkAna
+StdSegments : {
+  segmentSuffixes : [ "ent", "mid", "xit" ]
+  segmentVIDs : [ [ "TT_FrontHollow", "TT_FrontPA"], [ "TT_Mid", "TT_MidInner"], ["TT_Back"] ]
+}
+
 AllOpt : { fillMC : true
   trkqual : "TrkQual"
   fillTrkQual : true
@@ -141,6 +146,7 @@ AllOpt : { fillMC : true
   fillHits : true
   genealogyDepth : 5
   fillBestCrv : true
+
   bestCrvModules : [ "BestCrv" ]
   bestCrvInstances : [ "first" ]
   bestCrvBranches : [ "bestcrv" ]
@@ -149,34 +155,42 @@ AllOpt : { fillMC : true
 DeM : { input : "KFF"
   branch : "de"
   suffix : "DeM"
+  @table::StdSegments
 }
 UeM : { input : "KFF"
   branch : "ue"
   suffix : "UeM"
+  @table::StdSegments
 }
 DmuM : { input : "KFF"
   branch : "dm"
   suffix : "DmuM"
+  @table::StdSegments
 }
 UmuM : { input : "KFF"
   branch : "um"
   suffix : "UmuM"
+  @table::StdSegments
 }
 DeP : { input : "KFF"
   branch : "de"
   suffix : "DeP"
+  @table::StdSegments
 }
 UeP : { input : "KFF"
   branch : "ue"
   suffix : "UeP"
+  @table::StdSegments
 }
 DmuP : { input : "KFF"
   branch : "dm"
   suffix : "DmuP"
+  @table::StdSegments
 }
 UmuP : { input : "KFF"
   branch : "um"
   suffix : "UmuP"
+  @table::StdSegments
 }
 
 

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -57,7 +57,7 @@ namespace mu2e {
       void fillHitInfoMC(const KalSeedMC& kseedmc, TrkStrawHitInfoMC& tshinfomc, const TrkStrawHitMC& tshmc);
       void fillAllSimInfos(const KalSeedMC& kseedmc, std::vector<SimInfo>& siminfos, int n_generations);
       void fillPriInfo(const KalSeedMC& kseedmc, const PrimaryParticle& primary, SimInfo& priinfo);
-      void fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep, std::vector<int> const& vids, double target_time);
+      void fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep, std::vector<VirtualDetectorId> const& vids, double target_time);
 
       void fillHitInfoMCs(const KalSeedMC& kseedmc, std::vector<TrkStrawHitInfoMC>& tshinfomcs);
       void fillCaloClusterInfoMC(CaloClusterMC const& ccmc, CaloClusterInfoMC& ccimc);

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -164,7 +164,7 @@ namespace mu2e {
   }
 
   void InfoMCStructHelper::fillTrkInfoMCStep(const KalSeedMC& kseedmc, TrkInfoMCStep& trkinfomcstep,
-      std::vector<int> const& vids, double target_time) {
+      std::vector<VirtualDetectorId> const& vids, double target_time) {
 
     GeomHandle<DetectorSystem> det;
     GlobalConstantsHandle<ParticleDataList> pdt;


### PR DESCRIPTION
Hi everyone,

This PR adds a new feature to TrkAna: fcl-configurable virtual detector IDs. 

You can now define new branches with any virtual detector ID you like. TrkAna will create a reco and an MC branch. See the example fcl/TrkAnaReco_addStopTgtVDs.fcl for a bit more information. At the moment, this example only produces the correct output for the MC branch:

```
trkana->Scan("sqrt(demcpri.mom.mag2()):sqrt(demctgt.mom.mag2()):sqrt(demcent.mom.mag2())")
************************************************
*    Row   * sqrt(demc * sqrt(demc * sqrt(demc *
************************************************
*        0 * 104.97261 * 104.80454 * 104.66930 *
*        1 * 104.97260 * 104.67928 * 104.30360 *
*        2 * 104.97261 * 104.86999 * 104.52937 *
*        3 * 104.97261 * 104.93677 * 104.62403 *
*        4 * 104.97261 * 104.94821 * 104.70843 *
*        5 * 104.97261 * 104.52096 * 103.94999 *
```

and not for the reco branch. I will work out why this is before merging this in.

Thanks,
Andy