### PR TITLE
Small Fixes

### DIFF
--- a/inc/TrkStrawHitInfo.hh
+++ b/inc/TrkStrawHitInfo.hh
@@ -11,7 +11,8 @@ namespace mu2e
     int plane = 0, panel = 0, layer = 0, straw = 0;  // StrawId fields for the straw hit
     int state = 0;     // hit state, including activity and left-right ambiguity
     int algo = 0; // updater algorithm last used on this hit
-    Bool_t frozen = false; // was state frozen?
+    bool frozen = false; // was state frozen?
+    bool usetot, usedriftdt, useabsdt, usendvar; // flags
     float bkgqual = -1.0, signqual = -1.0, driftqual = -1.0, chi2qual = -1.0; // hit state assignment quality
     int earlyend = 0; // which end had the early TDC
     float edep = -1.0 ;        // reco energy deposition

--- a/inc/TrkStrawHitInfo.hh
+++ b/inc/TrkStrawHitInfo.hh
@@ -3,52 +3,39 @@
 //
 #ifndef TrkStrawHitInfoHH
 #define TrkStrawHitInfoHH
-#include "Rtypes.h"
 #include "Offline/DataProducts/inc/GenVector.hh"
 #include "Offline/DataProducts/inc/TrkTypes.hh"
 namespace mu2e
 {
   struct TrkStrawHitInfo {
-    Int_t plane, panel, layer, straw;  // StrawId fields for the straw hit
-    Int_t state;     // hit state, including activity and left-right ambiguity
-    Int_t algo; // updater algorithm last used on this hit
-    Bool_t frozen; // was state frozen?
-    Bool_t usetot, usedriftdt, useabsdt, usendvar; // flags
-    Float_t bkgqual, signqual, driftqual, chi2qual; // hit state assignment quality
-    Int_t driftend; // which end(s) was used in computing the drift
-    Float_t edep;        // reco energy deposition
-    Float_t htime;   // raw hit time
-    Float_t wdist;       // raw hit U position
-    Float_t werr;    // raw hit U position error estimate
-    Float_t tottdrift; // TOT expressed as drift time
-    TrkTypes::TOTTimes  tot;   // TOT times in ns from each end
-    Float_t ptoca, stoca;    // reference particle (sensor) time of closest approach (TOCA)
-    Float_t rdoca, rdocavar;   // reference (biased) DOCA from the track to the wire, signed by the angular momentum WRT the wire and the measurement end (and variance)
-    Float_t rdt, rtocavar;   // reference (biased) time difference (and variance) at POCA
-    Float_t udoca, udocavar; // unbiaed DOCA (and variance)
-    Float_t udt, utocavar;   // unbiased dt and variance
-    Float_t rupos, uupos; // POCA position along the straw WRT the straw middle
-    Float_t rdrift,cdrift,sderr,uderr,dvel,lang; // drift information
-    Float_t utresid, utresidmvar, utresidpvar; // unbiased time residual and associated measurement and parameter variances
-    Float_t udresid, udresidmvar, udresidpvar; // unbiased distance residual and associated measurement and parameter variances
-    Float_t rtresid, rtresidmvar, rtresidpvar; // reference time residual and associated measurement and parameter variances
-    Float_t rdresid, rdresidmvar, rdresidpvar; // reference distance residual and associated measurement and parameter variances
+    int plane = 0, panel = 0, layer = 0, straw = 0;  // StrawId fields for the straw hit
+    int state = 0;     // hit state, including activity and left-right ambiguity
+    int algo = 0; // updater algorithm last used on this hit
+    Bool_t frozen = false; // was state frozen?
+    float bkgqual = -1.0, signqual = -1.0, driftqual = -1.0, chi2qual = -1.0; // hit state assignment quality
+    int earlyend = 0; // which end had the early TDC
+    float edep = -1.0 ;        // reco energy deposition
+    float wdist = 0;       // raw hit U position
+    float werr = -1.0;    // raw hit U position error estimate
+    float tottdrift = 0; // TOT expressed as drift time
+    TrkTypes::TDCTimes etime = {0,0};   // raw hit time at each end
+    TrkTypes::TOTTimes  tot = {0,0};   // TOT times in ns from each end
+    float ptoca = 0, stoca = 0;    // reference particle (sensor) time of closest approach (TOCA)
+    float rdoca = 0, rdocavar = 0;   // reference (biased) DOCA from the track to the wire, signed by the angular momentum WRT the wire and the measurement end (and variance)
+    float rdt = 0, rtocavar = -1.0;   // reference (biased) time difference (and variance) at POCA
+    float udoca = 0, udocavar = -1.0; // unbiaed DOCA (and variance)
+    float udt = 0, utocavar = -1.0;   // unbiased dt and variance
+    float rupos = 0, uupos = 0; // POCA position along the straw WRT the straw middle
+    float rdrift = 0, cdrift = 0, sderr = -1.0, uderr = -1.0, dvel = 0, lang = 0; // drift information
+    float utresid = 0, utresidmvar = -1.0, utresidpvar = -1.0; // unbiased time residual and associated measurement and parameter variances
+    float udresid = 0, udresidmvar = -1.0, udresidpvar = -1.0; // unbiased distance residual and associated measurement and parameter variances
+    float rtresid = 0, rtresidmvar = -1.0, rtresidpvar = -1.0; // reference time residual and associated measurement and parameter variances
+    float rdresid = 0, rdresidmvar = -1.0, rdresidpvar = -1.0; // reference distance residual and associated measurement and parameter variances
+    float wdot = 0; // cosine of the angle between the track and wire
+    XYZVectorF poca; // POCA
     // not sure if we still want these
-    Float_t wdot;
-    XYZVectorF poca;
-    bool dhit, dactive;
-
-    TrkStrawHitInfo() : plane(-1), panel(-1), layer(-1), straw(-1), state(-10),driftend(-1),
-    edep(0), htime(0), wdist(0), werr(0),tottdrift(0), tot{0.0,0.0},
-    ptoca(0), stoca(0),
-    rdoca(0), rdocavar(0), rdt(0), rtocavar(0),
-    udoca(0.0), udocavar(0), udt(0), utocavar(0),
-    rupos(0),uupos(0), rdrift(0), cdrift(0), sderr(0), uderr(0), dvel(0), lang(0),
-    utresid(0), utresidmvar(0), utresidpvar(0),
-    udresid(0), udresidmvar(0), udresidpvar(0),
-    rtresid(0), rtresidmvar(0), rtresidpvar(0),
-    rdresid(0), rdresidmvar(0), rdresidpvar(0),
-    wdot(0), dhit(false), dactive(false) {}
+    bool dhit = false;
+    bool dactive = false;
   };
 }
 #endif

--- a/inc/TrkStrawHitInfo.hh
+++ b/inc/TrkStrawHitInfo.hh
@@ -13,6 +13,7 @@ namespace mu2e
     Int_t state;     // hit state, including activity and left-right ambiguity
     Int_t algo; // updater algorithm last used on this hit
     Bool_t frozen; // was state frozen?
+    Bool_t usetot, usedriftdt, useabsdt, usendvar; // flags
     Float_t bkgqual, signqual, driftqual, chi2qual; // hit state assignment quality
     Int_t driftend; // which end(s) was used in computing the drift
     Float_t edep;        // reco energy deposition

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -218,14 +218,12 @@ namespace mu2e {
       // find nearest segment
       auto ikseg = kseed.nearestSegment(ihit->_ptoca);
       if(ikseg != kseed.segments().end()){
-        XYZVectorF dir;
-        ikseg->helix().direction(ikseg->localFlt(ihit->trkLen()),dir);
-        auto tdir = GenVector::Hep3Vec(dir);
-        tshinfo.wdot = tdir.dot(straw.getDirection());
+        auto tdir(ikseg->momentum3().Unit());
+        tshinfo.wdot = tdir.Dot(straw.getDirection());
       }
       auto const& wiredir = straw.getDirection();
       auto const& mid = straw.getMidPoint();
-      CLHEP::Hep3Vector hpos = mid + wiredir*ihit->hitLen();
+      auto hpos = mid + wiredir*ihit->_wdist;
       tshinfo.poca = XYZVectorF(hpos);
 
       // count correlations with other TSH
@@ -326,6 +324,7 @@ namespace mu2e {
     }
   }
 
+  // this function won't work with KinKal fits and needs to be rewritten from scratch //FIXME
   void InfoStructHelper::fillTrkPIDInfo(const TrkCaloHitPID& tchp, const KalSeed& kseed, TrkPIDInfo& trkpidInfo) {
     mu2e::GeomHandle<mu2e::Calorimeter> calo;
     int n_trktchpid_vars = TrkCaloHitPID::n_vars;

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -114,7 +114,7 @@ namespace mu2e {
     uint16_t minplane(0), maxplane(0);
     for (auto ihit = kseed.hits().begin(); ihit != kseed.hits().end(); ++ihit) {
       ++trkinfo.nhits;
-      if (ihit->strawHitState()>WireHitState::inactive) {
+      if (ihit->strawHitState() > WireHitState::inactive){
         ++trkinfo.nactive;
         planes.insert(ihit->strawId().plane());
         minplane = std::min(minplane, ihit->strawId().plane());
@@ -160,6 +160,10 @@ namespace mu2e {
       auto const& straw = tracker.getStraw(ihit->strawId());
 
       tshinfo.state = ihit->_ambig;
+      tshinfo.usetot = ihit->_kkshflag.hasAnyProperty(KKSHFlag::tot);
+      tshinfo.usedriftdt = ihit->_kkshflag.hasAnyProperty(KKSHFlag::driftdt);
+      tshinfo.useabsdt = ihit->_kkshflag.hasAnyProperty(KKSHFlag::absdrift);
+      tshinfo.usendvar = ihit->_kkshflag.hasAnyProperty(KKSHFlag::nhdrift);
       tshinfo.algo = ihit->_algo;
       tshinfo.frozen = ihit->_frozen;
       tshinfo.bkgqual = ihit->_bkgqual;
@@ -265,7 +269,6 @@ namespace mu2e {
     if (kseed.hasCaloCluster()) {
       auto const& tch = kseed.caloHit();
       auto const& cc = tch.caloCluster();
-
       tchinfo.active = tch._flag.hasAllProperties(StrawHitFlag::active);
       tchinfo.did = cc->diskID();
       tchinfo.poca = tch._cpos;


### PR DESCRIPTION
This PR removes the use of the helix() function from the main processing, as that can fail when the reco track axis is near the z axis.  It also adds some flags.  The TrkPid function needs a complete rewrite.