### PR TITLE
Check for invalid artPtrs to SimParticles in CrvCoincidenceClusterMCs

### DIFF
--- a/src/BestCrvHitDeltaT_module.cc
+++ b/src/BestCrvHitDeltaT_module.cc
@@ -65,7 +65,6 @@ namespace mu2e {
 
   void BestCrvHitDeltaT::produce(art::Event& event) {
 
-std::cout<<"AAAAA "<<__FILE__<<"  "<<__LINE__<<std::endl;
     const auto& kalSeedHandle = event.getValidHandle<KalSeedCollection>(_kalSeedTag);
     const auto& crvCoincidenceHandle = event.getValidHandle<CrvCoincidenceClusterCollection>(_crvCoincidenceTag);
     auto firstAssns = std::make_unique<BestCrvAssns>();
@@ -105,7 +104,6 @@ std::cout<<"AAAAA "<<__FILE__<<"  "<<__LINE__<<std::endl;
     }
     event.put(std::move(firstAssns), "first");
     event.put(std::move(secondAssns), "second");
-std::cout<<"AAAAA "<<__FILE__<<"  "<<__LINE__<<std::endl;
   }
 }  // end namespace mu2e
 

--- a/src/BestCrvHitDeltaT_module.cc
+++ b/src/BestCrvHitDeltaT_module.cc
@@ -65,6 +65,7 @@ namespace mu2e {
 
   void BestCrvHitDeltaT::produce(art::Event& event) {
 
+std::cout<<"AAAAA "<<__FILE__<<"  "<<__LINE__<<std::endl;
     const auto& kalSeedHandle = event.getValidHandle<KalSeedCollection>(_kalSeedTag);
     const auto& crvCoincidenceHandle = event.getValidHandle<CrvCoincidenceClusterCollection>(_crvCoincidenceTag);
     auto firstAssns = std::make_unique<BestCrvAssns>();
@@ -104,6 +105,7 @@ namespace mu2e {
     }
     event.put(std::move(firstAssns), "first");
     event.put(std::move(secondAssns), "second");
+std::cout<<"AAAAA "<<__FILE__<<"  "<<__LINE__<<std::endl;
   }
 }  // end namespace mu2e
 

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -235,8 +235,8 @@ namespace mu2e {
   }
 
   void InfoMCStructHelper::fillCrvHitInfoMC(art::Ptr<CrvCoincidenceClusterMC> const& crvCoincMC, CrvHitInfoMC& crvHitInfoMC) {
-    if(crvCoincMC->HasMCInfo()) {
-      const art::Ptr<SimParticle> &simParticle = crvCoincMC->GetMostLikelySimParticle();
+    const art::Ptr<SimParticle> &simParticle = crvCoincMC->GetMostLikelySimParticle();
+    if(crvCoincMC->HasMCInfo() && simParticle.isAvailable()) {
       art::Ptr<SimParticle> primaryParticle = simParticle;
       art::Ptr<SimParticle> parentParticle = simParticle;
       art::Ptr<SimParticle> gparentParticle = simParticle;


### PR DESCRIPTION
Check for invalid artPtrs to SimParticles in CrvCoincidenceClusterMCs caused by noise hits.