### PR TITLE
Allow for Multiple CrvCoincidenceCollections

### DIFF
--- a/fcl/TrkAnaReco_multipleBestCrv_differentThresholds.fcl
+++ b/fcl/TrkAnaReco_multipleBestCrv_differentThresholds.fcl
@@ -1,0 +1,17 @@
+#include "TrkAna/fcl/TrkAnaReco.fcl"
+
+// Define the new BestCrv modules and add them to the path
+physics.producers.BestCrv6PEsDeM : @local::BestCrvDeM
+physics.producers.BestCrv6PEsDeM.crvCoincidenceTag : "SelectRecoMC:CrvCoincidenceClusterFinder6PEs"
+
+physics.TrkAnaTrigPath : [ @sequence::physics.TrkAnaTrigPath, BestCrv6PEsDeM ]
+
+// Then add them to TrkAna (NB DeM suffix not needed)
+physics.analyzers.TrkAnaNeg.candidate.options.bestCrvModules : [ "BestCrv", "BestCrv6PEs" ]
+
+// The BestCrvHitDeltaT_module.cc produces the first- and second-best crv hits.
+// Here we have two different modules and want the best candidate for each so we use "first" twice...
+physics.analyzers.TrkAnaNeg.candidate.options.bestCrvInstances : [ "first", "first" ]
+
+// This names the branches, which will translate to "debestcrv" and "debestcrv6PEs"
+physics.analyzers.TrkAnaNeg.candidate.options.bestCrvBranches : [ "bestcrv", "bestcrv6PEs" ]

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -70,7 +70,7 @@ TrkPIDProducersPath : [ TrkPIDDeM, TrkPIDDeP ]
 
 BestCrv : {
   module_type : BestCrvHitDeltaT
-  crvCoincidenceTag : "SelectRecoMC"
+  crvCoincidenceTag : "SelectRecoMC:CrvCoincidenceClusterFinder"
 }
 
 BestCrvDeM : @local::BestCrv
@@ -207,8 +207,8 @@ TrkAnaTreeMaker : {
   PBITag : "PBISim"
   PBTTag : "EWMProducer"
   PBTMCTag : "EWMProducer"
-  CrvCoincidenceModuleLabel : "SelectRecoMC"
-  CrvCoincidenceMCModuleLabel : "compressRecoMCs"
+  CrvCoincidenceModuleLabel : "SelectRecoMC:CrvCoincidenceClusterFinder"
+  CrvCoincidenceMCModuleLabel : "compressRecoMCs:CrvCoincidenceClusterMatchMC"
   CrvRecoPulseLabel : "SelectRecoMC"
   CrvStepLabel : "compressRecoMCs"
   SimParticleLabel : "compressRecoMCs"


### PR DESCRIPTION
This PR goes with Mu2e/Offline#973 and Mu2e/Production#244 and updates the default module labels used by TrkAna for the CrvCoincidenceCollections. In addition, there is also an example fcl for having multiple ```bestcrv``` branches from different CrvCoincidenceCollections