### PR TITLE
Allow bestcrvmc to come from different collections

### DIFF
--- a/fcl/TrkAnaReco.fcl
+++ b/fcl/TrkAnaReco.fcl
@@ -11,11 +11,14 @@ services : @local::Services.Reco
 
 physics :
 {
-  producers : { @table::TrkAnaReco.producers }
+  producers : {
+    @table::TrkAnaReco.producers
+    @table::TrkAnaReco.MCProducers
+  }
   analyzers : { @table::TrkAnaReco.analyzers }
 }
 
-physics.TrkAnaTrigPath : [ @sequence::TrkAnaReco.TrigSequence ]
+physics.TrkAnaTrigPath : [ @sequence::TrkAnaReco.MCTrigSequence, @sequence::TrkAnaReco.TrigSequence ]
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequence ]
 
 # Include more information (MC, full TrkQual and TrkPID branches)

--- a/fcl/TrkAnaReco_multipleBestCrv_differentThresholds.fcl
+++ b/fcl/TrkAnaReco_multipleBestCrv_differentThresholds.fcl
@@ -1,5 +1,9 @@
 #include "TrkAna/fcl/TrkAnaReco.fcl"
 
+// We want a singles Assns between reco and MC CrvCoincidenceClusters from all different collections
+physics.producers.MakeCrvCoincidenceClusterMCAssns.crvCoincidenceTags : [ "SelectRecoMC:CrvCoincidenceClusterFinder", "SelectRecoMC:CrvCoincidenceClusterFinder6PEs" ]
+physics.producers.MakeCrvCoincidenceClusterMCAssns.crvCoincidenceMCTags : [ "compressRecoMCs:CrvCoincidenceClusterMatchMC", "compressRecoMCs:CrvCoincidenceClusterMatchMC6PEs" ]
+
 // Define the new BestCrv modules and add them to the path
 physics.producers.BestCrv6PEsDeM : @local::BestCrvDeM
 physics.producers.BestCrv6PEsDeM.crvCoincidenceTag : "SelectRecoMC:CrvCoincidenceClusterFinder6PEs"

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -67,6 +67,16 @@ TrkPIDProducers : {
 }
 TrkPIDProducersPath : [ TrkPIDDeM, TrkPIDDeP ]
 
+MakeCrvCoincidenceClusterMCAssns : {
+  module_type : "MakeCrvCoincidenceClusterMCAssns"
+  crvCoincidenceTags : [ "SelectRecoMC:CrvCoincidenceClusterFinder" ]
+  crvCoincidenceMCTags : [ "compressRecoMCs:CrvCoincidenceClusterMatchMC" ]
+}
+
+MakeCrvCoincidenceClusterMCAssnsProducers : {
+  MakeCrvCoincidenceClusterMCAssns : @local::MakeCrvCoincidenceClusterMCAssns
+}
+MakeCrvCoincidenceClusterMCAssnsPath : [ MakeCrvCoincidenceClusterMCAssns ]
 
 BestCrv : {
   module_type : BestCrvHitDeltaT
@@ -215,6 +225,7 @@ TrkAnaTreeMaker : {
   MCTrajectoryLabel : "compressRecoMCs"
   CrvWaveformsModuleLabel : "compressRecoMCs"
   CrvDigiModuleLabel : "SelectRecoMC"
+  CrvCoincidenceClusterMCAssnsTag : "MakeCrvCoincidenceClusterMCAssns"
   CrvPlaneY : 2653
   FillMCInfo : true
   FillTrkQualInfo : true
@@ -266,6 +277,11 @@ TrkAnaReco : {
   TrigSequence : [ PBIWeight, @sequence::TrkQualProducersPath, @sequence::TrkPIDProducersPath, @sequence::BestCrvProducersPath ]
   EndSequenceNoMC : [ TrkAnaNeg, TrkAnaPos ]
   EndSequence : [ TrkAnaNeg, TrkAnaPos, genCountLogger ]
+
+  MCProducers : {
+    @table::MakeCrvCoincidenceClusterMCAssnsProducers
+  }
+  MCTrigSequence : [ @sequence::MakeCrvCoincidenceClusterMCAssnsPath ]
 }
 
 END_PROLOG

--- a/inc/BestCrvAssns.hh
+++ b/inc/BestCrvAssns.hh
@@ -2,8 +2,10 @@
 
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/RecoDataProducts/inc/CrvCoincidenceCluster.hh"
+#include "Offline/MCDataProducts/inc/CrvCoincidenceClusterMC.hh"
 
 namespace mu2e {
   // Assns between a KalSeed and a CrvCoincidenceCluster
   typedef art::Assns<mu2e::KalSeed, mu2e::CrvCoincidenceCluster> BestCrvAssns;
+  typedef art::Assns<mu2e::CrvCoincidenceCluster, mu2e::CrvCoincidenceClusterMC> CrvCoincidenceClusterMCAssns;
 }

--- a/src/MakeCrvCoincidenceClusterMCAssns_module.cc
+++ b/src/MakeCrvCoincidenceClusterMCAssns_module.cc
@@ -1,0 +1,92 @@
+//
+// Module that creates an Assns between a CrvCoincidenceCluster
+// and its associated CrvCoincidenceClusterMC
+//
+// Can take many collections of CrvCoincidenceClusters
+//
+// Original author: Andy Edmonds 2023-05-02
+//
+
+// Framework includes.
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/OptionalAtom.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/OptionalSequence.h"
+#include "fhiclcpp/types/Sequence.h"
+
+#include "TrkAna/inc/BestCrvAssns.hh"
+
+// C++ includes.
+#include <iostream>
+#include <string>
+#include <cmath>
+
+using namespace std;
+
+namespace mu2e {
+
+  class MakeCrvCoincicdenceClusterMCAssns : public art::EDProducer {
+
+  public:
+    struct Config {
+      using Name=fhicl::Name;
+      using Comment=fhicl::Comment;
+
+      fhicl::Sequence<art::InputTag> crvCoincidenceTags{Name("crvCoincidenceTags"), Comment("art::InputTags for CrvCoincidenceClusterCollections")};
+      fhicl::Sequence<art::InputTag> crvCoincidenceMCTags{Name("crvCoincidenceMCTags"), Comment("art::InputTags for CrvCoincidenceClusterMCCollections")};
+    };
+    typedef art::EDProducer::Table<Config> Parameters;
+
+    explicit MakeCrvCoincicdenceClusterMCAssns(const Parameters& conf);
+    virtual ~MakeCrvCoincicdenceClusterMCAssns() { }
+
+    void beginJob();
+    void produce(art::Event& e);
+
+  private:
+
+    // fhicl parameters
+    std::vector<art::InputTag> _crvCoincidenceTags;
+    std::vector<art::InputTag> _crvCoincidenceMCTags;
+  };
+
+  MakeCrvCoincicdenceClusterMCAssns::MakeCrvCoincicdenceClusterMCAssns(const Parameters& conf):
+    art::EDProducer(conf),
+    _crvCoincidenceTags(conf().crvCoincidenceTags()),
+    _crvCoincidenceMCTags(conf().crvCoincidenceMCTags())
+  {
+    produces<CrvCoincidenceClusterMCAssns>();
+  }
+
+  void MakeCrvCoincicdenceClusterMCAssns::beginJob( ){  }
+
+  void MakeCrvCoincicdenceClusterMCAssns::produce(art::Event& event) {
+
+    auto outputAssns = std::make_unique<CrvCoincidenceClusterMCAssns>();
+    for (size_t i_collection = 0; i_collection < _crvCoincidenceTags.size(); ++i_collection) {
+      const auto& crvCoincidenceHandle = event.getValidHandle<CrvCoincidenceClusterCollection>(_crvCoincidenceTags.at(i_collection));
+      const auto& crvCoincidenceMCHandle = event.getValidHandle<CrvCoincidenceClusterMCCollection>(_crvCoincidenceMCTags.at(i_collection));
+
+      if (crvCoincidenceHandle->size() != crvCoincidenceMCHandle->size()) {
+        throw cet::exception("MakeCrvCoincicdenceClusterMCAssns") << "CrvCoincidenceCollection and CrvCoincidenceMCCollection have different sizes (" << crvCoincidenceHandle->size() << " != " << crvCoincidenceMCHandle->size() << ")" << std::endl;
+      }
+
+      for(size_t i_crvCoinc = 0; i_crvCoinc != crvCoincidenceHandle->size(); ++i_crvCoinc) {
+        auto crvCoincPtr = art::Ptr<CrvCoincidenceCluster>(crvCoincidenceHandle, i_crvCoinc);
+        auto crvCoincMCPtr = art::Ptr<CrvCoincidenceClusterMC>(crvCoincidenceMCHandle, i_crvCoinc);
+        outputAssns->addSingle(crvCoincPtr, crvCoincMCPtr);
+      }
+    }
+    event.put(std::move(outputAssns));
+  }
+}  // end namespace mu2e
+
+// Part of the magic that makes this class a module.
+// create an instance of the module.  It also registers
+using mu2e::MakeCrvCoincicdenceClusterMCAssns;
+DEFINE_ART_MODULE(MakeCrvCoincicdenceClusterMCAssns);


### PR DESCRIPTION
Following on from #82 and associated PRs, Yuri noticed that the ```bestcrvmc``` branch can only get data from a single ```CrvCoincidenceClusterMCCollection```.

The solution I found is to create a single Assns to associate reco to MC CrvCoincidenceClusters and use that in TrkAna. The Assns is created in a new module (```MakeCrvCoincidenceClusterMCAssns```)