### PR TITLE
add init due to e28 warning

### DIFF
--- a/inc/RecoQualInfo.hh
+++ b/inc/RecoQualInfo.hh
@@ -10,6 +10,12 @@ namespace mu2e
 {
   struct RecoQualInfo {
     static const int MAX_QUALS = 50;
+
+    RecoQualInfo() {
+      n_quals = 0;
+      reset();
+    }
+
     const std::string leafname(std::vector<std::string> labels) {
       std::string leaves = "nquals/I:";
       for (std::vector<std::string>::const_iterator i_label = labels.begin(); i_label != labels.end(); ++i_label) {


### PR DESCRIPTION

  The whole e28 compiler warning message (uninitialized variables, fixed by this PR) follows.  There are probably other ways to fix it.

> In file included from /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/stl_iterator.h:85,
>                  from /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/stl_algobase.h:67,
>                  from /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/stl_tree.h:63,
>                  from /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/set:62,
>                  from ./Offline/GeneralUtilities/inc/ParameterSetHelpers.hh:16,
>                  from TrkAna/src/TrkAnaTreeMaker_module.cc:15:
> In function 'constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = mu2e::RecoQualInfo; _Args = {const mu2e::RecoQualInfo&}]',
>     inlined from 'static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = mu2e::RecoQualInfo; _Args = {const mu2e::RecoQualInfo&}; _Tp = mu2e::RecoQualInfo]' at /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/alloc_traits.h:539:21,
>     inlined from 'constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = mu2e::RecoQualInfo; _Alloc = std::allocator<mu2e::RecoQualInfo>]' at /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/stl_vector.h:1281:30,
>     inlined from 'mu2e::TrkAnaTreeMaker::TrkAnaTreeMaker(const Parameters&)' at TrkAna/src/TrkAnaTreeMaker_module.cc:390:25:
> /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/stl_construct.h:97:14: error: 'rqi' may be used uninitialized [-Werror=maybe-uninitialized]
>    97 |     { return ::new((void*)__location) _Tp(std::forward<_Args>(__args)...); }
>       |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> TrkAna/src/TrkAnaTreeMaker_module.cc: In constructor 'mu2e::TrkAnaTreeMaker::TrkAnaTreeMaker(const Parameters&)':
> TrkAna/src/TrkAnaTreeMaker_module.cc:389:20: note: 'rqi' declared here
>   389 |       RecoQualInfo rqi;
>       |                    ^~~
> In function 'constexpr decltype (::new(void*(0)) _Tp) std::construct_at(_Tp*, _Args&& ...) [with _Tp = mu2e::RecoQualInfo; _Args = {const mu2e::RecoQualInfo&}]',
>     inlined from 'static constexpr void std::allocator_traits<std::allocator<_Up> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = mu2e::RecoQualInfo; _Args = {const mu2e::RecoQualInfo&}; _Tp = mu2e::RecoQualInfo]' at /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/alloc_traits.h:539:21,
>     inlined from 'constexpr void std::vector<_Tp, _Alloc>::_M_realloc_insert(iterator, _Args&& ...) [with _Args = {const mu2e::RecoQualInfo&}; _Tp = mu2e::RecoQualInfo; _Alloc = std::allocator<mu2e::RecoQualInfo>]' at /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/vector.tcc:468:28,
>     inlined from 'constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = mu2e::RecoQualInfo; _Alloc = std::allocator<mu2e::RecoQualInfo>]' at /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/stl_vector.h:1287:21,
>     inlined from 'mu2e::TrkAnaTreeMaker::TrkAnaTreeMaker(const Parameters&)' at TrkAna/src/TrkAnaTreeMaker_module.cc:390:25:
> /cvmfs/mu2e.opensciencegrid.org/artexternals/gcc/v13_1_0/Linux64bit+3.10-2.17/include/c++/13.1.0/bits/stl_construct.h:97:14: error: 'rqi' may be used uninitialized [-Werror=maybe-uninitialized]
>    97 |     { return ::new((void*)__location) _Tp(std::forward<_Args>(__args)...); }
>       |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> TrkAna/src/TrkAnaTreeMaker_module.cc: In constructor 'mu2e::TrkAnaTreeMaker::TrkAnaTreeMaker(const Parameters&)':
> TrkAna/src/TrkAnaTreeMaker_module.cc:389:20: note: 'rqi' declared here
>   389 |       RecoQualInfo rqi;
>       |                    ^~~
> cc1plus: all warnings being treated as errors
> scons: *** [build/sl7-prof-e28-u048/TrkAna/tmp/src/TrkAnaTreeMaker_module.os] Error 1
> 