### PR TITLE
Fix NDOF calculation

### DIFF
--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -67,6 +67,7 @@ namespace mu2e {
     fillTrkInfoHits(kseed, trkinfo);
 
     trkinfo.chisq = kseed.chisquared();
+    trkinfo.ndof  = kseed.nDOF();
     trkinfo.fitcon = kseed.fitConsistency();
     trkinfo.nseg = kseed.nTrajSegments();
     trkinfo.maxgap = kseed._maxgap;
@@ -206,11 +207,6 @@ namespace mu2e {
       }
       trkinfo.nplanes = planes.size();
       trkinfo.planespan = abs(maxplane-minplane);
-    }
-
-    trkinfo.ndof = trkinfo.nactive -5; // this won't work with KinKal fits FIXME
-    if (kseed.hasCaloCluster()) {
-      ++trkinfo.ndof;
     }
   }
 


### PR DESCRIPTION
The existing calculation NDOF=nactive-nparams was wrong for KinKal fits, as noted.  The fix requires an upgrade to KalSeed, which is in Offline PR 1072, thus this PR is tied to that.
Note that the NDOF value recorded in existing mcs (reco) MDC2020 output files is wrong, and requires a reprocessing to fix.  The fit consistency value however was calculated using the correct NDOF.  On general grounds we should encourage analyzers to switch to fitconsistency over chisq/NDOF in analysis anways.