### PR TITLE
Fix nightly: change in CRV accessor

### DIFF
--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -422,9 +422,9 @@ namespace mu2e {
 
   void InfoStructHelper::fillCrvHitInfo(art::Ptr<CrvCoincidenceCluster> const& crvCoinc, CrvHitInfoReco& crvHitInfo) {
     crvHitInfo._crvSectorType = crvCoinc->GetCrvSectorType();
-    crvHitInfo._x = crvCoinc->GetAvgCounterPos().x();
-    crvHitInfo._y = crvCoinc->GetAvgCounterPos().y();
-    crvHitInfo._z = crvCoinc->GetAvgCounterPos().z();
+    crvHitInfo._x = crvCoinc->GetAvgHitPos().x();
+    crvHitInfo._y = crvCoinc->GetAvgHitPos().y();
+    crvHitInfo._z = crvCoinc->GetAvgHitPos().z();
     crvHitInfo._timeWindowStart = crvCoinc->GetStartTime();
     crvHitInfo._timeWindowEnd = crvCoinc->GetEndTime();
     crvHitInfo._PEs = crvCoinc->GetPEs();


### PR DESCRIPTION
Nightly validation failed because ```GetAvgCounterPos()``` no longer exists. Based on the PR that introduced that change, I think the correct new accessor is ```GetAvgHitPos()``` (asking Ralf review and confirm)