### PR TITLE
Add end information for SimParticles

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 TrkAna is a track-based ntuple for Mu2e analyses. Each entry in the ntuple corresponds to a single reconstructed track. 
 
-## Tutorial
+## Useful Links
 
-There is a tutorial for using TrkAna [here](tutorial/README.md)
+* [Mu2eWiki page](https://mu2ewiki.fnal.gov/wiki/TrkAna)
+* [spreadsheet explaining branch and leaf names](https://docs.google.com/spreadsheets/d/1IMZVgj74vxGTWqAFRtFEEcYChujJyc38VcopZh52jhc/edit)
+* [version history of TrkAna](https://mu2ewiki.fnal.gov/wiki/TrkAna#Version_History_.2F_TrkAna_Musings)
+* [tutorial](tutorial/README.md)

--- a/inc/SimInfo.hh
+++ b/inc/SimInfo.hh
@@ -23,6 +23,8 @@ namespace mu2e
     Int_t index; // index into the SimInfo vector
     XYZVectorF mom = XYZVectorF();  // origin momentumof the SimParticle
     XYZVectorF pos = XYZVectorF();  // origin position of the SimParticle
+    XYZVectorF endmom = XYZVectorF();  // end momentumof the SimParticle
+    XYZVectorF endpos = XYZVectorF();  // end position of the SimParticle
     MCRelationship prirel = MCRelationship::none; // relationship to the event primary particles
     MCRelationship trkrel = MCRelationship::none; // relationship to the particle that created hits in the track
     void reset() { *this = SimInfo(); }

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -213,6 +213,8 @@ namespace mu2e {
     siminfo.time = sp.startGlobalTime();
     siminfo.mom = XYZVectorF(sp.startMomentum());
     siminfo.pos = XYZVectorF(det->toDetector(sp.startPosition()));
+    siminfo.endmom = XYZVectorF(sp.endMomentum());
+    siminfo.endpos = XYZVectorF(det->toDetector(sp.endPosition()));
   }
 
   void InfoMCStructHelper::fillVDInfo(const KalSeed& kseed, const KalSeedMC& kseedmc, std::vector<MCStepInfo>& vdinfos) {

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -8,12 +8,6 @@ The exercises in this tutorial are designed to be self-paced and for both ROOT a
 
 If you have any questions, comments, or feedback, then you can either post on the ```#trkana``` channel of the [Mu2e Slack](https://mu2ewiki.fnal.gov/wiki/Slack), or [open a GitHub issue](https://github.com/Mu2e/TrkAna/issues)
 
-### Other useful links:
-
-* explanation of branches and leaves [spreadsheet](https://docs.google.com/spreadsheets/d/1IMZVgj74vxGTWqAFRtFEEcYChujJyc38VcopZh52jhc/edit)
-    * one tab for each major branch
-* version istory of TrkAna is on the [Mu2eWiki](https://mu2ewiki.fnal.gov/wiki/TrkAna#Version_History_.2F_TrkAna_Musings)
-
 ## Contents
 
 1. [Preliminary Information](pages/prelims.md): In this exercise, we will get some preliminary information about TrkAna.


### PR DESCRIPTION
It would be useful to have end information for the SimParticles and not just the start info (see Issue #109) so I've added it here. I've kept the names of the start position and momentum branches as ```mom``` and ```pos``` to avoid making a breaking change but I'm open to changing them to ```startmom``` and ```startpos``` for clarity