### PR TITLE
Fix branch structures.  Fix extracted script

### DIFF
--- a/fcl/TrkAnaExtracted.fcl
+++ b/fcl/TrkAnaExtracted.fcl
@@ -19,15 +19,14 @@ physics :
 physics.TrkAnaTrigPath : [ ]
 physics.TrkAnaEndPath : [ TrkAnaExt ]
 
-# Include more information (MC, full TrkQual and TrkPID branches)
 physics.analyzers.TrkAnaExt.candidate.options : @local::AllOpt
-physics.analyzers.TrkAnaExt.candidate.options.fillTrkQual : false
 physics.analyzers.TrkAnaExt.candidate.options.fillTrkPID : false
 physics.analyzers.TrkAnaExt.FillTriggerInfo : false
 physics.analyzers.TrkAnaExt.FitType : KinematicLine
+physics.analyzers.TrkAnaExt.candidate.branch : "trk"
 
 # for hit level diagnostics, set diagLevel to 2
-physics.analyzers.TrkAnaExt.diagLevel : 2
+physics.analyzers.TrkAnaExt.diagLevel : 1
 physics.analyzers.TrkAnaExt.FillMCInfo : true
 physics.analyzers.TrkAnaExt.FillCRVHits : true
 

--- a/fcl/prolog_trigger.fcl
+++ b/fcl/prolog_trigger.fcl
@@ -14,7 +14,6 @@ TrkAnaTrigger : {
     FillCaloMC : false
     RecoCountTag : ""
     FillTriggerInfo : true
-    FillTrkQualInfo : false
     FillTrkPIDInfo : false
     FillHitInfo : true
     FillTriggerInfo : false

--- a/inc/EventInfo.hh
+++ b/inc/EventInfo.hh
@@ -8,9 +8,9 @@
 namespace mu2e
 {
   struct EventInfo {
-    int eventid = 0;
-    int runid = 0;
-    int subrunid = 0; // run/event identification
+    int event = 0;
+    int run = 0;
+    int subrun = 0; // run/event identification
     int nprotons = 0; // estimated # of protons on target for this microbunch
     float pbtime = 0.0;
     float  pbterr = 0.0; // estimated proton bunch time (and error)

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -465,8 +465,8 @@ namespace mu2e {
             auto& mcssi = mcssis.at(ixtra);
             auto const& tag = _extraMCStepTags[ixtra];
             auto inst = tag.instance();
-            std::string  mcsiname = branch +"mcsic_" + inst;
-            std::string  mcssiname = branch + "mcssi_" + inst;
+            std::string  mcsiname = branch +"mcsic_" + inst + ".";
+            std::string  mcssiname = branch + "mcssi_" + inst + ".";
             _trkana->Branch(mcsiname.c_str(),mcsic,_buffsize,_splitlevel);
             _trkana->Branch(mcssiname.c_str(),mcssi,_buffsize,_splitlevel);
           }
@@ -701,9 +701,9 @@ namespace mu2e {
 
   void TrkAnaTreeMaker::fillEventInfo( const art::Event& event) {
     // fill basic event information
-    _einfo.eventid = event.event();
-    _einfo.runid = event.run();
-    _einfo.subrunid = event.subRun();
+    _einfo.event = event.event();
+    _einfo.run = event.run();
+    _einfo.subrun = event.subRun();
     // currently no reco nproton estimate TODO
 
     auto PBThandle = event.getValidHandle<mu2e::ProtonBunchTime>(_PBTTag);


### PR DESCRIPTION
The existing branch names for protonabsorber etc. caused errors when creating an event loop class with MakeClass.  