### PR TITLE
Updated CRV branch names and added a PEs per layer variable. 

### DIFF
--- a/fcl/TrkAnaExtracted.fcl
+++ b/fcl/TrkAnaExtracted.fcl
@@ -20,16 +20,16 @@ physics.TrkAnaTrigPath : [ ]
 physics.TrkAnaEndPath : [ TrkAnaExt ]
 
 # Include more information (MC, full TrkQual and TrkPID branches)
-physics.analyzers.TrkAnaExt.candidate.options : @local::AllOpt
-physics.analyzers.TrkAnaExt.candidate.options.fillTrkQual : false
-physics.analyzers.TrkAnaExt.candidate.options.fillTrkPID : false
+# physics.analyzers.TrkAnaExt.candidate.options : @local::AllOpt
+# physics.analyzers.TrkAnaExt.candidate.options.fillTrkQual : false
+# physics.analyzers.TrkAnaExt.candidate.options.fillTrkPID : false
 physics.analyzers.TrkAnaExt.FillTriggerInfo : false
 physics.analyzers.TrkAnaExt.FitType : KinematicLine
 
 # for hit level diagnostics, set diagLevel to 2
 physics.analyzers.TrkAnaExt.diagLevel : 2
 physics.analyzers.TrkAnaExt.FillMCInfo : true
-physics.analyzers.TrkAnaExt.FillCRVHits : true
+physics.analyzers.TrkAnaExt.FillCRVCoincs : true
 
 services.GeometryService.inputFile: "Production/JobConfig/cosmic/geom_cosmic_extracted.txt"
 services.TFileService.fileName: "nts.owner.trkanaextracted-reco.version.sequencer.root"

--- a/fcl/TrkAnaReco.fcl
+++ b/fcl/TrkAnaReco.fcl
@@ -29,7 +29,7 @@ physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequence ]
 # for hit level diagnostics, set diagLevel to 2
 physics.analyzers.TrkAna.diagLevel : 1
 physics.analyzers.TrkAna.FillMCInfo : true
-physics.analyzers.TrkAna.FillCRVHits : true
+physics.analyzers.TrkAna.FillCRVCoincs : true
 physics.analyzers.TrkAna.FillTriggerInfo : false
 physics.analyzers.TrkAna.FitType : LoopHelix
 

--- a/fcl/TrkAnaReco_wTrkQualFilter.fcl
+++ b/fcl/TrkAnaReco_wTrkQualFilter.fcl
@@ -53,11 +53,11 @@ physics.analyzers.TrkAnaPos.candidate.options : @local::AllOpt
 # for hit level diagnostics, set diagLevel to 2
 physics.analyzers.TrkAnaNeg.diagLevel : 1
 physics.analyzers.TrkAnaNeg.FillMCInfo : true
-physics.analyzers.TrkAnaNeg.FillCRVHits : true
+physics.analyzers.TrkAnaNeg.FillCRVCoincs : true
 physics.analyzers.TrkAnaNeg.FillTriggerInfo : true
 physics.analyzers.TrkAnaPos.diagLevel : 1
 physics.analyzers.TrkAnaPos.FillMCInfo : true
-physics.analyzers.TrkAnaPos.FillCRVHits : true
+physics.analyzers.TrkAnaPos.FillCRVCoincs : true
 physics.analyzers.TrkAnaPos.FillTriggerInfo : true
 
 services.TFileService.fileName: "nts.owner.trkana-reco.version.sequencer.root"

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -173,7 +173,7 @@ TrkAnaTreeMaker : {
   FillTriggerInfo : true
   TriggerProcessName : "Mix"
   ProcessEmptyEvents : false
-  FillCRVHits : true
+  FillCRVCoincs : true
   FillCRVPulses : false
   FillCaloMC : true
   FillHelixInfo : false

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -175,6 +175,7 @@ TrkAnaTreeMaker : {
   ProcessEmptyEvents : false
   FillCRVCoincs : true
   FillCRVPulses : false
+  FillCRVDigis : false
   FillCaloMC : true
   FillHelixInfo : false
   PrimaryParticleTag : "compressRecoMCs"

--- a/fcl/prolog_trigger.fcl
+++ b/fcl/prolog_trigger.fcl
@@ -9,7 +9,7 @@ TrkAnaTrigger : {
     supplements : []
     ExtraMCStepCollectionTags : []
     diagLevel : 2
-    FillCRVHits : false
+    FillCRVCoincs : false
     FillMCInfo : true
     FillCaloMC : false
     RecoCountTag : ""

--- a/inc/CrvHitInfoReco.hh
+++ b/inc/CrvHitInfoReco.hh
@@ -35,7 +35,10 @@ namespace mu2e
       angle(coincidenceAngle)
     {
       // Copy PEsPerLayer array elements
-      for (int i = 0; i < 4; i++) this->PEsPerLayer[i] = PEsPerLayer[i];
+      for (int i = 0; i < 4; i++) 
+      {
+        this->PEsPerLayer[i] = PEsPerLayer[i];
+      }
     }
   };
 

--- a/inc/CrvHitInfoReco.hh
+++ b/inc/CrvHitInfoReco.hh
@@ -5,6 +5,7 @@
 #include "Offline/DataProducts/inc/CRVId.hh"
 #include "CLHEP/Vector/ThreeVector.h"
 #include <vector>
+#include <array>
 #include "Rtypes.h"
 
 namespace mu2e
@@ -18,29 +19,24 @@ namespace mu2e
     Float_t             timeEnd = -1;   //last hit time
     Float_t             time = -1; // average hit time
     Float_t             PEs = -1;   //total number of PEs for this cluster
-    Float_t             PEsPerLayer[CRVId::nLayers] = {-1};  // PEs per layer for this cluster
+    std::array<Float_t, CRVId::nLayers> PEsPerLayer = {-1};  // PEs per layer for this cluster
     Int_t               nHits = -1;      //number of coincidence hits in this cluster
     Int_t               nLayers = -1;      //number of coincidence layers in this cluster
     Float_t             angle = -999;   //coincidence direction
 
     CrvHitInfoReco(){}
-    CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, float PEsPerLayer[4], int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle) :
+    CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, std::array<float, CRVId::nLayers> PEsPerLayer, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle) :
       sectorType(sectorType),
       pos(hpos),
       timeStart(timeWindowStart),
       timeEnd(timeWindowEnd),
       time(timeAvg),
       PEs(PEs),
+      PEsPerLayer(PEsPerLayer),
       nHits(nCoincidenceHits),
       nLayers(nCoincidenceLayers),
       angle(coincidenceAngle)
-    {
-      // Copy PEsPerLayer array elements
-      for (size_t i=0; i<CRVId::nLayers; i++) 
-      {
-        this->PEsPerLayer[i] = PEsPerLayer[i];
-      }
-    }
+    {}
   };
 
   typedef std::vector<CrvHitInfoReco> CrvHitInfoRecoCollection;  //this is the reco vector which will be stored in the main TTree

--- a/inc/CrvHitInfoReco.hh
+++ b/inc/CrvHitInfoReco.hh
@@ -2,6 +2,7 @@
 #define CrvHitInfoReco_hh
 
 #include "Offline/DataProducts/inc/GenVector.hh"
+#include "Offline/DataProducts/inc/CRVId.hh"
 #include "CLHEP/Vector/ThreeVector.h"
 #include <vector>
 #include "Rtypes.h"
@@ -17,7 +18,7 @@ namespace mu2e
     Float_t             timeEnd = -1;   //last hit time
     Float_t             time = -1; // average hit time
     Float_t             PEs = -1;   //total number of PEs for this cluster
-    Float_t             PEsPerLayer[4] = {-1};  // PEs per layer for this cluster
+    Float_t             PEsPerLayer[CRVId::nLayers] = {-1};  // PEs per layer for this cluster
     Int_t               nHits = -1;      //number of coincidence hits in this cluster
     Int_t               nLayers = -1;      //number of coincidence layers in this cluster
     Float_t             angle = -999;   //coincidence direction
@@ -35,7 +36,7 @@ namespace mu2e
       angle(coincidenceAngle)
     {
       // Copy PEsPerLayer array elements
-      for (int i = 0; i < 4; i++) 
+      for (size_t i=0; i<CRVId::nLayers; i++) 
       {
         this->PEsPerLayer[i] = PEsPerLayer[i];
       }

--- a/inc/CrvHitInfoReco.hh
+++ b/inc/CrvHitInfoReco.hh
@@ -16,13 +16,14 @@ namespace mu2e
     Float_t             timeStart = -1; //first hit time
     Float_t             timeEnd = -1;   //last hit time
     Float_t             time = -1; // average hit time
-    Int_t               PEs = -1;                   //total number of PEs for this cluster
+    Float_t             PEs = -1;   //total number of PEs for this cluster
+    Float_t             PEsPerLayer[4] = {-1};  // PEs per layer for this cluster
     Int_t               nHits = -1;      //number of coincidence hits in this cluster
     Int_t               nLayers = -1;      //number of coincidence layers in this cluster
     Float_t             angle = -999;   //coincidence direction
 
     CrvHitInfoReco(){}
-    CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, int PEs, int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle) :
+    CrvHitInfoReco(int sectorType, CLHEP::Hep3Vector hpos, float timeWindowStart, float timeWindowEnd, float timeAvg, float PEs, float PEsPerLayer[4], int nCoincidenceHits, int nCoincidenceLayers, float coincidenceAngle) :
       sectorType(sectorType),
       pos(hpos),
       timeStart(timeWindowStart),
@@ -32,7 +33,10 @@ namespace mu2e
       nHits(nCoincidenceHits),
       nLayers(nCoincidenceLayers),
       angle(coincidenceAngle)
-    {}
+    {
+      // Copy PEsPerLayer array elements
+      for (int i = 0; i < 4; i++) this->PEsPerLayer[i] = PEsPerLayer[i];
+    }
   };
 
   typedef std::vector<CrvHitInfoReco> CrvHitInfoRecoCollection;  //this is the reco vector which will be stored in the main TTree

--- a/inc/CrvInfoHelper.hh
+++ b/inc/CrvInfoHelper.hh
@@ -16,6 +16,8 @@
 #include "Offline/MCDataProducts/inc/SimParticle.hh"
 #include "Offline/MCDataProducts/inc/CrvCoincidenceClusterMC.hh"
 #include "Offline/MCDataProducts/inc/MCTrajectory.hh"
+#include "Offline/CosmicRayShieldGeom/inc/CosmicRayShield.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "art/Framework/Principal/Handle.h"
 
 namespace mu2e
@@ -39,8 +41,12 @@ namespace mu2e
       void FillCrvPulseInfoCollections(
           art::Handle<CrvRecoPulseCollection> const& crvRecoPulses,
           art::Handle<CrvDigiMCCollection> const& crvDigiMCs,
+          CrvPulseInfoRecoCollection &recoInfo, CrvHitInfoMCCollection &MCInfo);
+
+      void FillCrvDigiInfoCollections(
+          art::Handle<CrvRecoPulseCollection> const& crvRecoPulses,
           art::Handle<CrvDigiCollection> const& crvDigis,
-          CrvPulseInfoRecoCollection &recoInfo, CrvHitInfoMCCollection &MCInfo, CrvWaveformInfoCollection &waveformInfo);
+          CrvWaveformInfoCollection &digiInfo);
 
     private:
       static const art::Ptr<SimParticle> &FindPrimaryParticle(const art::Ptr<SimParticle> &simParticle)
@@ -60,7 +66,25 @@ namespace mu2e
         const art::Ptr<SimParticle> &parentParticle = simParticle->hasParent() ? simParticle->parent() : simParticle;
         return parentParticle->hasParent() ? parentParticle->parent() : parentParticle;
       }
-
+      static const std::map<int,int> GetSiPMMap(GeomHandle<CosmicRayShield> &CRS) // Helper function for FillCrvDigiInfoCollections and FillCrvPulseInfoCollections
+      {
+        // Create SiPM map to extract sequantial SiPM IDs
+        const std::vector<std::shared_ptr<CRSScintillatorBar> > &counters = CRS->getAllCRSScintillatorBars();
+        std::vector<std::shared_ptr<CRSScintillatorBar> >::const_iterator iter;
+        int iSiPM = 0;
+        std::map<int,int> sipm_map;
+        for(iter=counters.begin(); iter!=counters.end(); iter++)
+        {
+          const CRSScintillatorBarIndex &barIndex = (*iter)->index();
+          for(int SiPM=0; SiPM<4; SiPM++)
+          {
+            if(!(*iter)->getBarDetail().hasCMB(SiPM%2)) continue;
+            sipm_map[barIndex.asInt()*4 + SiPM] = iSiPM;
+            iSiPM++;
+          }
+        }
+        return sipm_map;
+      }
       static const int _trajectorySimParticleId = 300001;  //only temporarily here for some tests
   };
 

--- a/inc/CrvInfoHelper.hh
+++ b/inc/CrvInfoHelper.hh
@@ -8,6 +8,7 @@
 #include "TrkAna/inc/CrvSummaryMC.hh"
 #include "TrkAna/inc/CrvPlaneInfoMC.hh"
 #include "TrkAna/inc/CrvPulseInfoReco.hh"
+#include "Offline/DataProducts/inc/CRVId.hh"
 #include "Offline/RecoDataProducts/inc/CrvCoincidenceCluster.hh"
 #include "Offline/RecoDataProducts/inc/CrvRecoPulse.hh"
 #include "Offline/RecoDataProducts/inc/CrvDigi.hh"
@@ -76,10 +77,10 @@ namespace mu2e
         for(iter=counters.begin(); iter!=counters.end(); iter++)
         {
           const CRSScintillatorBarIndex &barIndex = (*iter)->index();
-          for(int SiPM=0; SiPM<4; SiPM++)
+          for(size_t SiPM=0; SiPM<CRVId::nChanPerBar; SiPM++)
           {
             if(!(*iter)->getBarDetail().hasCMB(SiPM%2)) continue;
-            sipm_map[barIndex.asInt()*4 + SiPM] = iSiPM;
+            sipm_map[barIndex.asInt()*CRVId::nChanPerBar + SiPM] = iSiPM;
             iSiPM++;
           }
         }

--- a/src/CrvInfoHelper.cc
+++ b/src/CrvInfoHelper.cc
@@ -210,7 +210,7 @@ namespace mu2e
 
       //Reco pulses information
       int SiPM = crvRecoPulse->GetSiPMNumber();
-      int SiPMId = sipm_map.find(barIndex.asInt()*4 + SiPM)->second;
+      int SiPMId = sipm_map.find(barIndex.asInt()*CRVId::nChanPerBar + SiPM)->second;
       CLHEP::Hep3Vector HitPos = CrvHelper::GetCrvCounterPos(CRS, barIndex);
       recoInfo.emplace_back(HitPos, barIndex.asInt(), sectorNumber, SiPMId,
           crvRecoPulse->GetPEs(), crvRecoPulse->GetPEsPulseHeight(), crvRecoPulse->GetPulseHeight(),

--- a/src/CrvInfoHelper.cc
+++ b/src/CrvInfoHelper.cc
@@ -38,7 +38,7 @@ namespace mu2e
       const CrvCoincidenceCluster &cluster = crvCoincidences->at(i);
 
       // Get the PEs per layer from the reco pulses
-      float PEsPerLayer_[4] = {0.}; // Four layers, each one initiliased to zero PEs in a static array
+      float PEsPerLayer_[CRVId::nLayers] = {0.}; // Four layers, each one initiliased to zero PEs in a static array
       const std::vector<art::Ptr<CrvRecoPulse> > coincRecoPulses_ = cluster.GetCrvRecoPulses(); // Get the reco pulses from the coincidence 
       for(size_t j=0; j<coincRecoPulses_.size(); j++) // Loop through the pulses
       {
@@ -54,7 +54,7 @@ namespace mu2e
       }
       // Sanity check for PEsPerLayer
       float PEsPerLayerSum = 0.; 
-      for (size_t j=0; j<4; j++) PEsPerLayerSum += PEsPerLayer_[j];
+      for (size_t j=0; j<CRVId::nLayers; j++) PEsPerLayerSum += PEsPerLayer_[j];
       float deltaPEs = abs(PEsPerLayerSum - cluster.GetPEs());
       if (deltaPEs > 1e-3) std::cout<<"CrvInfoHelper warning: the sum of PEs per layer differs by " << deltaPEs << " from total PEs in the coincidence!"<<std::endl;
 

--- a/src/CrvInfoHelper.cc
+++ b/src/CrvInfoHelper.cc
@@ -38,7 +38,7 @@ namespace mu2e
       const CrvCoincidenceCluster &cluster = crvCoincidences->at(i);
 
       // Get the PEs per layer from the reco pulses
-      float PEsPerLayer_[CRVId::nLayers] = {0.}; // Four layers, each one initiliased to zero PEs in a static array
+      std::array<float, CRVId::nLayers> PEsPerLayer_ = {0.}; // PEs per layer array, each element initiliased to zero
       const std::vector<art::Ptr<CrvRecoPulse> > coincRecoPulses_ = cluster.GetCrvRecoPulses(); // Get the reco pulses from the coincidence 
       for(size_t j=0; j<coincRecoPulses_.size(); j++) // Loop through the pulses
       {

--- a/src/CrvInfoHelper.cc
+++ b/src/CrvInfoHelper.cc
@@ -52,11 +52,6 @@ namespace mu2e
         // Sum PEs for this coincidence, indexed by layer number
         PEsPerLayer_[layerNumber] += coincRecoPulses_.at(j)->GetPEsNoFit(); // The coincidences were found using the NoFit option, so use that here as well  
       }
-      // Sanity check for PEsPerLayer
-      float PEsPerLayerSum = 0.; 
-      for (size_t j=0; j<CRVId::nLayers; j++) PEsPerLayerSum += PEsPerLayer_[j];
-      float deltaPEs = abs(PEsPerLayerSum - cluster.GetPEs());
-      if (deltaPEs > 1e-3) std::cout<<"CrvInfoHelper warning: the sum of PEs per layer differs by " << deltaPEs << " from total PEs in the coincidence!"<<std::endl;
 
       //fill the Reco collection
       recoInfo.emplace_back(

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -158,7 +158,7 @@ namespace mu2e {
         fhicl::Atom<art::InputTag> crvDigisTag{Name("CrvDigisTag"), Comment("Tag for CrvDigi Collection"), art::InputTag()};
         // CRV -- flags
         fhicl::Atom<bool> fillcrvcoincs{Name("FillCRVCoincs"),Comment("Flag for turning on crv CoincidenceClusterbranches"), false};
-        fhicl::Atom<bool> fillcrvpulses{Name("FillCRVPulses"),Comment("Flag for turning on crvpulses(mc), crvwaveforminfo branches"), false};
+        fhicl::Atom<bool> fillcrvpulses{Name("FillCRVPulses"),Comment("Flag for turning on crvpulses(mc), crvdigis branches"), false};
         // CRV -- other
         fhicl::Atom<double> crvPlaneY{Name("CrvPlaneY"),2751.485};  //y of center of the top layer of the CRV-T counters.  This belongs in KinKalGeom as an intersection plane, together with the rest of the CRV planes FIXME
         // MC truth
@@ -275,7 +275,7 @@ namespace mu2e {
       CrvSummaryMC   _crvsummarymc;
       std::vector<CrvPlaneInfoMC> _crvcoincsmcplane;
       std::vector<CrvPulseInfoReco> _crvpulses;
-      std::vector<CrvWaveformInfo> _crvwaveforminfo;
+      std::vector<CrvWaveformInfo> _crvdigis;
       std::vector<CrvHitInfoMC> _crvpulsesmc;
       std::vector<CrvHitInfoReco> _crvrecoinfo;
       // helices
@@ -473,7 +473,7 @@ namespace mu2e {
       _trkana->Branch("crvcoincs.",&_crvcoincs,_buffsize,_splitlevel);
       if(_fillcrvpulses) {
         _trkana->Branch("crvpulses.",&_crvpulses,_buffsize,_splitlevel);
-        _trkana->Branch("crvwaveforminfo.",&_crvwaveforminfo,_buffsize,_splitlevel);
+        _trkana->Branch("crvdigis.",&_crvdigis,_buffsize,_splitlevel);
       }
 
       if(_fillmc){
@@ -643,7 +643,7 @@ namespace mu2e {
       _crvcoincsmc.clear();
       _crvcoincsmcplane.clear();
       _crvpulses.clear();
-      _crvwaveforminfo.clear();
+      _crvdigis.clear();
       _crvpulsesmc.clear();
 
       event.getByLabel(_conf.crvCoincidencesTag(),_crvCoincidences);
@@ -660,7 +660,7 @@ namespace mu2e {
                                            _crvsummary, _crvsummarymc, _crvcoincsmcplane, _crvPlaneY);
       if(_fillcrvpulses){
         _crvHelper.FillCrvPulseInfoCollections(_crvRecoPulses, _crvDigiMCs, _crvDigis,
-                                               _crvpulses, _crvpulsesmc, _crvwaveforminfo);
+                                               _crvpulses, _crvpulsesmc, _crvdigis);
       }
     }
 

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -269,11 +269,11 @@ namespace mu2e {
       // CRV (output)
       std::vector<CrvHitInfoReco> _crvcoincs;
       std::map<BranchIndex, std::vector<CrvHitInfoReco>> _allBestCrvs; // there can be more than one of these per track type
-      std::vector<CrvHitInfoMC> _crvhitmc;
+      std::vector<CrvHitInfoMC> _crvcoincsmc;
       std::map<BranchIndex, std::vector<CrvHitInfoMC>> _allBestCrvMCs;
       CrvSummaryReco _crvsummary;
       CrvSummaryMC   _crvsummarymc;
-      std::vector<CrvPlaneInfoMC> _crvhitmcplane;
+      std::vector<CrvPlaneInfoMC> _crvcoincsmcplane;
       std::vector<CrvPulseInfoReco> _crvpulseinfo;
       std::vector<CrvWaveformInfo> _crvwaveforminfo;
       std::vector<CrvHitInfoMC> _crvpulseinfomc;
@@ -477,8 +477,8 @@ namespace mu2e {
 
       if(_fillmc){
         _trkana->Branch("crvsummarymc.",&_crvsummarymc,_buffsize,_splitlevel);
-        _trkana->Branch("crvhitmc.",&_crvhitmc,_buffsize,_splitlevel);
-        _trkana->Branch("crvhitmcplane.",&_crvhitmcplane,_buffsize,_splitlevel);
+        _trkana->Branch("crvcoincsmc.",&_crvcoincsmc,_buffsize,_splitlevel);
+        _trkana->Branch("crvcoincsmcplane.",&_crvcoincsmcplane,_buffsize,_splitlevel);
         if(_crvpulses) {
           _trkana->Branch("crvpulseinfomc.",&_crvpulseinfomc,_buffsize,_splitlevel);
         }
@@ -639,8 +639,8 @@ namespace mu2e {
     if(_fillcrvcoincs){
       // clear vectors
       _crvcoincs.clear();
-      _crvhitmc.clear();
-      _crvhitmcplane.clear();
+      _crvcoincsmc.clear();
+      _crvcoincsmcplane.clear();
       _crvpulseinfo.clear();
       _crvwaveforminfo.clear();
       _crvpulseinfomc.clear();
@@ -655,8 +655,8 @@ namespace mu2e {
       }
       _crvHelper.FillCrvHitInfoCollections(
                                            _crvCoincidences, _crvCoincidenceMCs,
-                                           _crvRecoPulses, _crvSteps, _mcTrajectories,_crvcoincs, _crvhitmc,
-                                           _crvsummary, _crvsummarymc, _crvhitmcplane, _crvPlaneY);
+                                           _crvRecoPulses, _crvSteps, _mcTrajectories,_crvcoincs, _crvcoincsmc,
+                                           _crvsummary, _crvsummarymc, _crvcoincsmcplane, _crvPlaneY);
       if(_crvpulses){
         _crvHelper.FillCrvPulseInfoCollections(_crvRecoPulses, _crvDigiMCs, _crvDigis,
                                                _crvpulseinfo, _crvpulseinfomc, _crvwaveforminfo);

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -158,7 +158,7 @@ namespace mu2e {
         fhicl::Atom<art::InputTag> crvDigisTag{Name("CrvDigisTag"), Comment("Tag for CrvDigi Collection"), art::InputTag()};
         // CRV -- flags
         fhicl::Atom<bool> fillcrvcoincs{Name("FillCRVCoincs"),Comment("Flag for turning on crv CoincidenceClusterbranches"), false};
-        fhicl::Atom<bool> crvpulses{Name("FillCRVPulses"),Comment("Flag for turning on crvpulseinfo(mc), crvwaveforminfo branches"), false};
+        fhicl::Atom<bool> fillcrvpulses{Name("FillCRVPulses"),Comment("Flag for turning on crvpulses(mc), crvwaveforminfo branches"), false};
         // CRV -- other
         fhicl::Atom<double> crvPlaneY{Name("CrvPlaneY"),2751.485};  //y of center of the top layer of the CRV-T counters.  This belongs in KinKalGeom as an intersection plane, together with the rest of the CRV planes FIXME
         // MC truth
@@ -264,7 +264,7 @@ namespace mu2e {
       art::Handle<CrvDigiCollection>                 _crvDigis;
       art::Handle<CrvStepCollection>                 _crvSteps;
       // CRV -- fhicl parameters
-      bool _fillcrvcoincs, _crvpulses;
+      bool _fillcrvcoincs, _fillcrvpulses;
       double _crvPlaneY;  // needs to move to KinKalGeom FIXME
       // CRV (output)
       std::vector<CrvHitInfoReco> _crvcoincs;
@@ -274,9 +274,9 @@ namespace mu2e {
       CrvSummaryReco _crvsummary;
       CrvSummaryMC   _crvsummarymc;
       std::vector<CrvPlaneInfoMC> _crvcoincsmcplane;
-      std::vector<CrvPulseInfoReco> _crvpulseinfo;
+      std::vector<CrvPulseInfoReco> _crvpulses;
       std::vector<CrvWaveformInfo> _crvwaveforminfo;
-      std::vector<CrvHitInfoMC> _crvpulseinfomc;
+      std::vector<CrvHitInfoMC> _crvpulsesmc;
       std::vector<CrvHitInfoReco> _crvrecoinfo;
       // helices
       HelixInfo _hinfo;
@@ -312,6 +312,7 @@ namespace mu2e {
     _fillcalomc(conf().fillCaloMC()),
     // CRV
     _fillcrvcoincs(conf().fillcrvcoincs()),
+    _fillcrvpulses(conf().fillcrvpulses()),
     _infoMCStructHelper(conf().infoMCStructHelper()),
     _buffsize(conf().buffsize()),
     _splitlevel(conf().splitlevel())
@@ -470,8 +471,8 @@ namespace mu2e {
       // coincidence branches should be here FIXME
       _trkana->Branch("crvsummary.",&_crvsummary,_buffsize,_splitlevel);
       _trkana->Branch("crvcoincs.",&_crvcoincs,_buffsize,_splitlevel);
-      if(_crvpulses) {
-        _trkana->Branch("crvpulseinfo.",&_crvpulseinfo,_buffsize,_splitlevel);
+      if(_fillcrvpulses) {
+        _trkana->Branch("crvpulses.",&_crvpulses,_buffsize,_splitlevel);
         _trkana->Branch("crvwaveforminfo.",&_crvwaveforminfo,_buffsize,_splitlevel);
       }
 
@@ -479,8 +480,8 @@ namespace mu2e {
         _trkana->Branch("crvsummarymc.",&_crvsummarymc,_buffsize,_splitlevel);
         _trkana->Branch("crvcoincsmc.",&_crvcoincsmc,_buffsize,_splitlevel);
         _trkana->Branch("crvcoincsmcplane.",&_crvcoincsmcplane,_buffsize,_splitlevel);
-        if(_crvpulses) {
-          _trkana->Branch("crvpulseinfomc.",&_crvpulseinfomc,_buffsize,_splitlevel);
+        if(_fillcrvpulses) {
+          _trkana->Branch("crvpulsesmc.",&_crvpulsesmc,_buffsize,_splitlevel);
         }
       }
     }
@@ -641,9 +642,9 @@ namespace mu2e {
       _crvcoincs.clear();
       _crvcoincsmc.clear();
       _crvcoincsmcplane.clear();
-      _crvpulseinfo.clear();
+      _crvpulses.clear();
       _crvwaveforminfo.clear();
-      _crvpulseinfomc.clear();
+      _crvpulsesmc.clear();
 
       event.getByLabel(_conf.crvCoincidencesTag(),_crvCoincidences);
       event.getByLabel(_conf.crvRecoPulsesTag(),_crvRecoPulses);
@@ -657,9 +658,9 @@ namespace mu2e {
                                            _crvCoincidences, _crvCoincidenceMCs,
                                            _crvRecoPulses, _crvSteps, _mcTrajectories,_crvcoincs, _crvcoincsmc,
                                            _crvsummary, _crvsummarymc, _crvcoincsmcplane, _crvPlaneY);
-      if(_crvpulses){
+      if(_fillcrvpulses){
         _crvHelper.FillCrvPulseInfoCollections(_crvRecoPulses, _crvDigiMCs, _crvDigis,
-                                               _crvpulseinfo, _crvpulseinfomc, _crvwaveforminfo);
+                                               _crvpulses, _crvpulsesmc, _crvwaveforminfo);
       }
     }
 

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -158,7 +158,8 @@ namespace mu2e {
         fhicl::Atom<art::InputTag> crvDigisTag{Name("CrvDigisTag"), Comment("Tag for CrvDigi Collection"), art::InputTag()};
         // CRV -- flags
         fhicl::Atom<bool> fillcrvcoincs{Name("FillCRVCoincs"),Comment("Flag for turning on crv CoincidenceClusterbranches"), false};
-        fhicl::Atom<bool> fillcrvpulses{Name("FillCRVPulses"),Comment("Flag for turning on crvpulses(mc), crvdigis branches"), false};
+        fhicl::Atom<bool> fillcrvpulses{Name("FillCRVPulses"),Comment("Flag for turning on crvpulses(mc) branches"), false};
+        fhicl::Atom<bool> fillcrvdigis{Name("FillCRVDigis"),Comment("Flag for turning on crvdigis branch"), false};
         // CRV -- other
         fhicl::Atom<double> crvPlaneY{Name("CrvPlaneY"),2751.485};  //y of center of the top layer of the CRV-T counters.  This belongs in KinKalGeom as an intersection plane, together with the rest of the CRV planes FIXME
         // MC truth
@@ -264,7 +265,7 @@ namespace mu2e {
       art::Handle<CrvDigiCollection>                 _crvDigis;
       art::Handle<CrvStepCollection>                 _crvSteps;
       // CRV -- fhicl parameters
-      bool _fillcrvcoincs, _fillcrvpulses;
+      bool _fillcrvcoincs, _fillcrvpulses, _fillcrvdigis;
       double _crvPlaneY;  // needs to move to KinKalGeom FIXME
       // CRV (output)
       std::vector<CrvHitInfoReco> _crvcoincs;
@@ -313,6 +314,7 @@ namespace mu2e {
     // CRV
     _fillcrvcoincs(conf().fillcrvcoincs()),
     _fillcrvpulses(conf().fillcrvpulses()),
+    _fillcrvdigis(conf().fillcrvdigis()),
     _infoMCStructHelper(conf().infoMCStructHelper()),
     _buffsize(conf().buffsize()),
     _splitlevel(conf().splitlevel())
@@ -473,9 +475,10 @@ namespace mu2e {
       _trkana->Branch("crvcoincs.",&_crvcoincs,_buffsize,_splitlevel);
       if(_fillcrvpulses) {
         _trkana->Branch("crvpulses.",&_crvpulses,_buffsize,_splitlevel);
+      }
+      if(_fillcrvdigis) {
         _trkana->Branch("crvdigis.",&_crvdigis,_buffsize,_splitlevel);
       }
-
       if(_fillmc){
         _trkana->Branch("crvsummarymc.",&_crvsummarymc,_buffsize,_splitlevel);
         _trkana->Branch("crvcoincsmc.",&_crvcoincsmc,_buffsize,_splitlevel);
@@ -659,9 +662,14 @@ namespace mu2e {
                                            _crvRecoPulses, _crvSteps, _mcTrajectories,_crvcoincs, _crvcoincsmc,
                                            _crvsummary, _crvsummarymc, _crvcoincsmcplane, _crvPlaneY);
       if(_fillcrvpulses){
-        _crvHelper.FillCrvPulseInfoCollections(_crvRecoPulses, _crvDigiMCs, _crvDigis,
-                                               _crvpulses, _crvpulsesmc, _crvdigis);
+        _crvHelper.FillCrvPulseInfoCollections(_crvRecoPulses, _crvDigiMCs,
+                                              _crvpulses, _crvpulsesmc);
       }
+      if(_fillcrvdigis){
+        _crvHelper.FillCrvDigiInfoCollections(_crvRecoPulses, _crvDigis,                                         
+                                              _crvdigis);
+      }
+
     }
 
 

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -157,7 +157,7 @@ namespace mu2e {
         fhicl::Atom<art::InputTag> crvDigiMCsTag{Name("CrvDigiMCsTag"), Comment("Tag for CrvDigiMC Collection"), art::InputTag()};
         fhicl::Atom<art::InputTag> crvDigisTag{Name("CrvDigisTag"), Comment("Tag for CrvDigi Collection"), art::InputTag()};
         // CRV -- flags
-        fhicl::Atom<bool> crvhits{Name("FillCRVHits"),Comment("Flag for turning on crv CoincidenceClusterbranches"), false};
+        fhicl::Atom<bool> fillcrvcoincs{Name("FillCRVCoincs"),Comment("Flag for turning on crv CoincidenceClusterbranches"), false};
         fhicl::Atom<bool> crvpulses{Name("FillCRVPulses"),Comment("Flag for turning on crvpulseinfo(mc), crvwaveforminfo branches"), false};
         // CRV -- other
         fhicl::Atom<double> crvPlaneY{Name("CrvPlaneY"),2751.485};  //y of center of the top layer of the CRV-T counters.  This belongs in KinKalGeom as an intersection plane, together with the rest of the CRV planes FIXME
@@ -264,10 +264,10 @@ namespace mu2e {
       art::Handle<CrvDigiCollection>                 _crvDigis;
       art::Handle<CrvStepCollection>                 _crvSteps;
       // CRV -- fhicl parameters
-      bool _crvhits, _crvpulses;
+      bool _fillcrvcoincs, _crvpulses;
       double _crvPlaneY;  // needs to move to KinKalGeom FIXME
       // CRV (output)
-      std::vector<CrvHitInfoReco> _crvhit;
+      std::vector<CrvHitInfoReco> _crvcoincs;
       std::map<BranchIndex, std::vector<CrvHitInfoReco>> _allBestCrvs; // there can be more than one of these per track type
       std::vector<CrvHitInfoMC> _crvhitmc;
       std::map<BranchIndex, std::vector<CrvHitInfoMC>> _allBestCrvMCs;
@@ -311,7 +311,7 @@ namespace mu2e {
     _fillmc(conf().fillmc()),
     _fillcalomc(conf().fillCaloMC()),
     // CRV
-    _crvhits(conf().crvhits()),
+    _fillcrvcoincs(conf().fillcrvcoincs()),
     _infoMCStructHelper(conf().infoMCStructHelper()),
     _buffsize(conf().buffsize()),
     _splitlevel(conf().splitlevel())
@@ -466,10 +466,10 @@ namespace mu2e {
     }
     // calorimeter information for the downstream electron track
     // general CRV info
-    if(_crvhits) {
+    if(_fillcrvcoincs) {
       // coincidence branches should be here FIXME
       _trkana->Branch("crvsummary.",&_crvsummary,_buffsize,_splitlevel);
-      _trkana->Branch("crvhit.",&_crvhit,_buffsize,_splitlevel);
+      _trkana->Branch("crvcoincs.",&_crvcoincs,_buffsize,_splitlevel);
       if(_crvpulses) {
         _trkana->Branch("crvpulseinfo.",&_crvpulseinfo,_buffsize,_splitlevel);
         _trkana->Branch("crvwaveforminfo.",&_crvwaveforminfo,_buffsize,_splitlevel);
@@ -636,9 +636,9 @@ namespace mu2e {
 
     // TODO we want MC information when we don't have a track
     // fill general CRV info
-    if(_crvhits){
+    if(_fillcrvcoincs){
       // clear vectors
-      _crvhit.clear();
+      _crvcoincs.clear();
       _crvhitmc.clear();
       _crvhitmcplane.clear();
       _crvpulseinfo.clear();
@@ -655,7 +655,7 @@ namespace mu2e {
       }
       _crvHelper.FillCrvHitInfoCollections(
                                            _crvCoincidences, _crvCoincidenceMCs,
-                                           _crvRecoPulses, _crvSteps, _mcTrajectories,_crvhit, _crvhitmc,
+                                           _crvRecoPulses, _crvSteps, _mcTrajectories,_crvcoincs, _crvhitmc,
                                            _crvsummary, _crvsummarymc, _crvhitmcplane, _crvPlaneY);
       if(_crvpulses){
         _crvHelper.FillCrvPulseInfoCollections(_crvRecoPulses, _crvDigiMCs, _crvDigis,


### PR DESCRIPTION
1.  Updated CRV branch names (following discussion with Andy, Ralf, and Yuri): 
- `crvhit` —> `crvcoincs`;
- `crvpulseinfo` —> `crvpulses`;
- `crvwaveforminfo` —> `crvdigis`.

2. Added a new leaf to `crvcoincs` tree: `float PEsPerLayer[4]`. This is an array of photoelectron counts indexed by layer number (four layers per module), which is filled by looping through the reco pulses for each coincidence cluster. See [Mu2e-doc-47954](https://mu2e-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=47954). I don't see any change in the `TrkAna` run time with this additional `for` loop. 

3. As a side note, the original `PEs` leaf was changed from an `int` to a `float`, after discussing with Ralf and Yuri. The convention that `PEs` are integers is outdated.


