### PR TITLE
Update to use KalSeedPtrs and add example of using a merged track collection

### DIFF
--- a/fcl/TrkAnaReco.fcl
+++ b/fcl/TrkAnaReco.fcl
@@ -18,7 +18,7 @@ physics :
   analyzers : { @table::TrkAnaReco.analyzers }
 }
 
-physics.TrkAnaTrigPath : [ PBIWeight, TrkQualDeM ]
+physics.TrkAnaTrigPath : [ @sequence::MergeKKProducersPath, PBIWeight, TrkQualDeM ]
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequence ]
 
 # Include more information (MC, full TrkQual and TrkPID branches)

--- a/fcl/TrkAnaReco_mergedKalSeeds.fcl
+++ b/fcl/TrkAnaReco_mergedKalSeeds.fcl
@@ -1,0 +1,10 @@
+#include "TrkAna/fcl/TrkAnaReco.fcl"
+
+physics.producers.MergeKalSeeds : {
+      module_type : MergeKalSeeds
+      KalSeedCollections : ["KKDeM", "KKDeP", "KKUeM", "KKUeP", "KKDmuM", "KKDmuP", "KKUmuM", "KKUmuP" ]
+}
+
+physics.analyzers.TrkAna.branches : [ {input : "MergeKalSeeds" branch : "trk" } ]
+
+physics.TrkAnaTrigPath : [ MergeKalSeeds, PBIWeight, TrkQualDeM ]

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -94,42 +94,74 @@ AllOpt : {
   matchDepth : -1
 }
 
-DeM : { input : "KK"
+# With move to using KalSeedPtr need to "merge" KalSeeds so that we get KalSeedPtr collections
+MergeKK : { module_type : MergeKalSeeds }
+MergeKKDeM           : @local::MergeKK
+MergeKKDeM.KalSeedCollections : [ "KKDeM" ]
+MergeKKUeM           : @local::MergeKK
+MergeKKUeM.KalSeedCollections : [ "KKUeM" ]
+MergeKKDmuM          : @local::MergeKK
+MergeKKDmuM.KalSeedCollections : [ "KKDmuM" ]
+MergeKKUmuM          : @local::MergeKK
+MergeKKUmuM.KalSeedCollections : [ "KKUmuM" ]
+MergeKKDeP           : @local::MergeKK
+MergeKKDeP.KalSeedCollections : [ "KKDeP" ]
+MergeKKUeP           : @local::MergeKK
+MergeKKUeP.KalSeedCollections : [ "KKUeP" ]
+MergeKKDmuP          : @local::MergeKK
+MergeKKDmuP.KalSeedCollections : [ "KKDmuP" ]
+MergeKKUmuP          : @local::MergeKK
+MergeKKUmuP.KalSeedCollections : [ "KKUmuP" ]
+
+MergeKKProducers : {
+  MergeKKDeM : @local::MergeKKDeM
+  MergeKKUeM : @local::MergeKKUeM
+  MergeKKDeP : @local::MergeKKDeP
+  MergeKKUeP : @local::MergeKKUeP
+  MergeKKDmuM : @local::MergeKKDmuM
+  MergeKKDmuP : @local::MergeKKDmuP
+  MergeKKUmuM : @local::MergeKKUmuM
+  MergeKKUmuP : @local::MergeKKUmuP
+}
+MergeKKProducersPath : [ MergeKKDeM, MergeKKUeM, MergeKKDmuM, MergeKKDeP, MergeKKUeP, MergeKKDmuP, MergeKKUmuM, MergeKKUmuP ]
+
+
+DeM : { input : "MergeKK"
   branch : "dem"
   suffix : "DeM"
   options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }
   trkQualTag : "TrkQualDeM"
 }
-UeM : { input : "KK"
+UeM : { input : "MergeKK"
   branch : "uem"
   suffix : "UeM"
 }
-DmuM : { input : "KK"
+DmuM : { input : "MergeKK"
   branch : "dmm"
   suffix : "DmuM"
 }
-UmuM : { input : "KK"
+UmuM : { input : "MergeKK"
   branch : "umm"
   suffix : "UmuM"
 }
-DeP : { input : "KK"
+DeP : { input : "MergeKK"
   branch : "dep"
   suffix : "DeP"
   options : { fillMC : true   genealogyDepth : -1 }
 }
-UeP : { input : "KK"
+UeP : { input : "MergeKK"
   branch : "uep"
   suffix : "UeP"
 }
-DmuP : { input : "KK"
+DmuP : { input : "MergeKK"
   branch : "dmp"
   suffix : "DmuP"
 }
-UmuP : { input : "KK"
+UmuP : { input : "MergeKK"
   branch : "ump"
   suffix : "UmuP"
 }
-Ext : { input : "KK"
+Ext : { input : "MergeKK"
   branch : "kl"
   suffix : "Line"
 }
@@ -181,6 +213,7 @@ TrkAnaReco : {
     PBIWeight : @local::PBIWeight
     @table::TrkQualProducers
     @table::TrkPIDProducers
+    @table::MergeKKProducers
   }
 
   analyzers : {


### PR DESCRIPTION
This PR updates TrkAna to use a collection of KalSeedPtrs rather than a collection of KalSeeds. This makes it easy to combine track collections into one and have a single branch for all tracks. I have added an example fcl configuration file (```TrkAnaReco_mergedKalSeeds.fcl```) that merges all KalSeeds into one collection and puts it all in one ```trk``` branch.

The behavior of TrkAnaReco.fcl hasn't changed. In order to support both one branch and multiple branches, I have added ```MergeKalSeeds``` modules that "merge" a single KalSeedCollection to get a KalSeedPtrCollection. I have validated TrkAnaReco.fcl with the validation script before and after making changes and the histograms are identical as reported by ```valCompare```