### PR TITLE
Migrate trigger script to ptr-based collections

### DIFF
--- a/fcl/TrkAnaTriggerMC.fcl
+++ b/fcl/TrkAnaTriggerMC.fcl
@@ -27,6 +27,7 @@ physics : {
       branches : [ @local::TrkAnaTrigger.TTtprDe ]
       KalSeedMCAssns: "SelectRecoMCtprDe"
       SelectEvents : [  "globalTrigger:tprDe_highP_stopTarg"  ]
+      TriggerProcessName : "globalTrigger"
     }
     TAcprDe : {
       @table::TrkAnaTrigger.TrkAnaTT
@@ -34,6 +35,8 @@ physics : {
       branches : [ @local::TrkAnaTrigger.TTcprDe ]
       KalSeedMCAssns: "SelectRecoMCcprDe"
       SelectEvents : [ "globalTrigger:cprDe_highP_stopTarg"  ]
+      TriggerProcessName : "globalTrigger"
+
     }
     #    TAmprDe : {
     #      @table::TrkAnaTrigger.TrkAnaTT
@@ -45,7 +48,6 @@ physics : {
   }
   #  EndPath : [TAtprDe, TAcprDe, TAmprDe]
   EndPath : [TAtprDe, TAcprDe]
-  TTKSFDePath : [
   TrigPath : [ "MergeTTKSFDe", "MergeTTCalSeedFitDe" ]
 }
 

--- a/fcl/TrkAnaTriggerMC.fcl
+++ b/fcl/TrkAnaTriggerMC.fcl
@@ -10,6 +10,16 @@ source : {
 }
 
 physics : {
+  producers : {
+    MergeTTKSFDe : {
+      module_type : MergeKalSeeds
+      KalSeedCollections : ["TTKSFDe"]
+    }
+    MergeTTCalSeedFitDe : {
+      module_type : MergeKalSeeds
+      KalSeedCollections : ["TTCalSeedFitDe"]
+    }
+  }
   analyzers : {
     TAtprDe : {
       @table::TrkAnaTrigger.TrkAnaTT
@@ -25,8 +35,20 @@ physics : {
       KalSeedMCAssns: "SelectRecoMCcprDe"
       SelectEvents : [ "globalTrigger:cprDe_highP_stopTarg"  ]
     }
+    #    TAmprDe : {
+    #      @table::TrkAnaTrigger.TrkAnaTT
+    #      FitType : LoopHelix
+    #      branches : [ @local::TrkAnaTrigger.TTmprDe ]
+    #      KalSeedMCAssns: "SelectRecoMCmprDe"
+    #      SelectEvents : [ "globalTrigger:mprDe_highP_stopTarg"  ]
+    #    }
   }
+  #  EndPath : [TAtprDe, TAcprDe, TAmprDe]
   EndPath : [TAtprDe, TAcprDe]
+  TTKSFDePath : [
+  TrigPath : [ "MergeTTKSFDe", "MergeTTCalSeedFitDe" ]
 }
+
 end_paths : [ EndPath ]
+physics.trigger_paths : [ "TrigPath" ]
 services.TFileService.fileName: "nts.owner.trkana-triggerMC.version.sequencer.root"

--- a/fcl/TrkAnaTriggerMC.fcl
+++ b/fcl/TrkAnaTriggerMC.fcl
@@ -19,6 +19,14 @@ physics : {
       module_type : MergeKalSeeds
       KalSeedCollections : ["TTCalSeedFitDe"]
     }
+    MergeTTAprKSFDe : {
+      module_type : MergeKalSeeds
+      KalSeedCollections : ["TTAprKSF"]
+    }
+    MergeTTMprKSFDe : {
+      module_type : MergeKalSeeds
+      KalSeedCollections : ["TTMprKSFDe"]
+    }
   }
   analyzers : {
     TAtprDe : {
@@ -38,17 +46,24 @@ physics : {
       TriggerProcessName : "globalTrigger"
 
     }
-    #    TAmprDe : {
-    #      @table::TrkAnaTrigger.TrkAnaTT
-    #      FitType : LoopHelix
-    #      branches : [ @local::TrkAnaTrigger.TTmprDe ]
-    #      KalSeedMCAssns: "SelectRecoMCmprDe"
-    #      SelectEvents : [ "globalTrigger:mprDe_highP_stopTarg"  ]
-    #    }
+    TAaprDe : {
+      @table::TrkAnaTrigger.TrkAnaTT
+      FitType : LoopHelix
+      branches : [ @local::TrkAnaTrigger.TTaprDe ]
+      KalSeedMCAssns: "SelectRecoMCaprDe"
+      SelectEvents : [ "globalTrigger:apr_highP_stopTarg"  ]
+      TriggerProcessName : "globalTrigger"
+    }
+    TAmprDe : {
+      @table::TrkAnaTrigger.TrkAnaTT
+      FitType : LoopHelix
+      branches : [ @local::TrkAnaTrigger.TTmprDe ]
+      KalSeedMCAssns: "SelectRecoMCmprDe"
+      SelectEvents : [ "globalTrigger:mprDe_highP_stopTarg"  ]
+    }
   }
-  #  EndPath : [TAtprDe, TAcprDe, TAmprDe]
-  EndPath : [TAtprDe, TAcprDe]
-  TrigPath : [ "MergeTTKSFDe", "MergeTTCalSeedFitDe" ]
+  EndPath : [TAtprDe, TAcprDe, TAaprDe, TAmprDe ]
+  TrigPath : [ "MergeTTKSFDe", "MergeTTCalSeedFitDe", "MergeTTAprKSFDe", "MergeTTMprKSFDe"]
 }
 
 end_paths : [ EndPath ]

--- a/fcl/prolog_trigger.fcl
+++ b/fcl/prolog_trigger.fcl
@@ -35,6 +35,18 @@ TrkAnaTrigger : {
     suffix : "De"
     options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }
   }
+  TTaprDe : {
+    input : "MergeTTAprKSF"
+    branch : "trk"
+    suffix : "De"
+    options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }
+  }
+  TTmprDe : {
+    input : "MergeTTMprKSF"
+    branch : "trk"
+    suffix : "De"
+    options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }
+  }
 }
 
 END_PROLOG

--- a/fcl/prolog_trigger.fcl
+++ b/fcl/prolog_trigger.fcl
@@ -24,13 +24,13 @@ TrkAnaTrigger : {
     }
   }
   TTtprDe : {
-    input : "TTKSF"
+    input : "MergeTTKSF"
     branch : "trk"
     suffix : "De"
     options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }
   }
   TTcprDe : {
-    input : "TTCalSeedFit"
+    input : "MergeTTCalSeedFit"
     branch : "trk"
     suffix : "De"
     options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }

--- a/inc/HelixInfo.hh
+++ b/inc/HelixInfo.hh
@@ -5,16 +5,17 @@
 #define TrkAna_HelixInfo_hh
 namespace mu2e {
   struct HelixInfo {
-    int nch, ncha;
-    int nsh, nsha;
-    unsigned flag;
-    float t0err;
-    float mom;
-    float chi2xy;
-    float chi2fz;
-    float ecalo;
-    void reset() { nch = nsh = ncha = nsha = -1; flag = 0;
-      t0err = mom = chi2xy = chi2fz = ecalo =-1.0; }
+    int nch = -1;
+    int ncha = -1;
+    int nsh = -1;
+    int nsha = -1;
+    int flag = -1;
+    float t0err = -1;
+    float mom = -1;
+    float chi2xy = -1;
+    float chi2fz = -1;
+    float ecalo = -1;
+    void reset() { *this = HelixInfo(); }
   };
 }
 #endif


### PR DESCRIPTION
This fix relies on Offline PR 1267, which is now merged.  For now I've kept the structure that this script creates 2 TTrees (tpr and cpr), but given the indirection afforded by the Ptr collection these can now be combined into a single tree, which I'll do in a separate PR.  That PR will also add the new Apr and Mpr trigger paths.