### PR TITLE
Added trigger_paths and end_paths (needed for mu2ejobdef) 

### DIFF
--- a/fcl/TrkAnaExtracted.fcl
+++ b/fcl/TrkAnaExtracted.fcl
@@ -19,6 +19,9 @@ physics :
 physics.TrkAnaTrigPath : [ @sequence::MergeKKNoFieldPath ]
 physics.TrkAnaEndPath : [ TrkAnaExt ]
 
+physics.trigger_paths : [ TrkAnaTrigPath ]
+physics.end_paths : [ TrkAnaEndPath ]
+
 # Include more information (MC, full TrkQual and TrkPID branches)
 physics.analyzers.TrkAnaExt.branches[0].options.fillMC : true
 physics.analyzers.TrkAnaExt.branches[0].options.genealogyDepth : 5

--- a/fcl/TrkAnaReco.fcl
+++ b/fcl/TrkAnaReco.fcl
@@ -21,6 +21,9 @@ physics :
 physics.TrkAnaTrigPath : [ @sequence::MergeKKProducersPath, PBIWeight, TrkQualDeM ]
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequence ]
 
+physics.trigger_paths : [ TrkAnaTrigPath ]
+physics.end_paths : [ TrkAnaEndPath ]
+
 # Include more information (MC, full TrkQual and TrkPID branches)
 # TODO: add these options back
 #physics.analyzers.TrkAnaNeg.candidate.options : @local::AllOpt

--- a/fcl/TrkAnaRecoEnsemble-Data.fcl
+++ b/fcl/TrkAnaRecoEnsemble-Data.fcl
@@ -3,5 +3,6 @@
 physics.analyzers.TrkAna.FillMCInfo : false
 
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequenceNoMC ]
+physics.end_paths : [ TrkAnaEndPath ]
 
 services.TFileService.fileName: "nts.owner.trkana-reco-ensemble-data.version.sequencer.root"

--- a/fcl/TrkAnaRecoEnsemble-MC.fcl
+++ b/fcl/TrkAnaRecoEnsemble-MC.fcl
@@ -1,5 +1,6 @@
 #include "TrkAna/fcl/TrkAnaReco.fcl"
 
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequenceNoMC ]
+physics.end_paths : [ TrkAnaEndPath ]
 
 services.TFileService.fileName: "nts.owner.trkana-reco-ensemble-mc.version.sequencer.root"

--- a/fcl/TrkAnaReco_MultipleTrkQual.fcl
+++ b/fcl/TrkAnaReco_MultipleTrkQual.fcl
@@ -4,3 +4,4 @@
 physics.producers.TrkQualNewDeP : @local::TrkQualDeP
 physics.producers.TrkQualNewDeP.TrainingName : "TrkQualPosNew"
 physics.TrkAnaTrigPath : [ @sequence::TrkAnaReco.TrigSequence, TrkQualNewDeP ]
+physics.trigger_paths : [ TrkAnaTrigPath ]

--- a/fcl/TrkAnaReco_ceSimReco.fcl
+++ b/fcl/TrkAnaReco_ceSimReco.fcl
@@ -7,4 +7,7 @@ physics.analyzers.TrkAna.FillTriggerInfo : false
 physics.TrkAnaTrigPath : [ MergeKKDeM, PBIWeight, TrkQualDeM, TrkPIDDeM ]
 physics.TrkAnaEndPath : [ TrkAna, genCountLogger ]
 
+physics.trigger_paths : [ TrkAnaTrigPath ]
+physics.end_paths : [ TrkAnaEndPath ]
+
 services.TFileService.fileName: "nts.owner.trkana-ce-sim-reco.version.sequencer.root"

--- a/fcl/TrkAnaReco_mergedKalSeeds.fcl
+++ b/fcl/TrkAnaReco_mergedKalSeeds.fcl
@@ -8,3 +8,4 @@ physics.producers.MergeKalSeeds : {
 physics.analyzers.TrkAna.branches : [ {input : "MergeKalSeeds" branch : "trk" } ]
 
 physics.TrkAnaTrigPath : [ MergeKalSeeds, PBIWeight, TrkQualDeM ]
+physics.trigger_paths : [ TrkAnaTrigPath ]

--- a/fcl/TrkAnaReco_multipleBestCrv_differentThresholds.fcl
+++ b/fcl/TrkAnaReco_multipleBestCrv_differentThresholds.fcl
@@ -9,6 +9,7 @@ physics.producers.BestCrv6PEsDeM : @local::BestCrvDeM
 physics.producers.BestCrv6PEsDeM.crvCoincidenceTag : "SelectRecoMC:CrvCoincidenceClusterFinder6PEs"
 
 physics.TrkAnaTrigPath : [ @sequence::physics.TrkAnaTrigPath, BestCrv6PEsDeM ]
+physics.trigger_paths : [ TrkAnaTrigPath ]
 
 // Then add them to TrkAna (NB DeM suffix not needed)
 physics.analyzers.TrkAnaNeg.candidate.options.bestCrvModules : [ "BestCrv", "BestCrv6PEs" ]

--- a/fcl/TrkAnaReco_wTrkQualFilter.fcl
+++ b/fcl/TrkAnaReco_wTrkQualFilter.fcl
@@ -33,8 +33,11 @@ physics.producers.TrkQualNegDeM.TrainingName : "TrkQualNeg"
 physics.TrkAnaTrigPath : [ @sequence::TrkAnaReco.TrigSequence, trkQualFilter ]
 physics.TrkAnaNegTrigPath : [ @sequence::TrkAnaReco.TrigSequence, TrkQualNegDeM, trkQualNegFilter ]
 #physics.TrkAnaBothTrigPath : [ @sequence::physics.TrkAnaTrigPath, @sequence::physics.TrkAnaNegTrigPath ]
+# I'm not sure how to handle TrkAnaNegTrigPath.
+physics.trigger_paths : [ TrkAnaTrigPath ]
 
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequence ]
+physics.end_paths : [ TrkAnaEndPath ]
 
 # Take events that pass one filter
 physics.analyzers.TrkAnaNeg.SelectEvents : [ TrkAnaTrigPath ]


### PR DESCRIPTION
Referring to [Mu2e/TrkAna/issues/169](https://github.com/Mu2e/TrkAna/issues/169): 

"Attempts to set up a grid submission using TrkAna fcl files with `mu2ejobdef` will result in an error relating to the fact that `physics.trigger_paths` and `physics.end_paths` are not defined."

I've added `trigger_paths` and `end_paths` in every file where `TrkAnaTrigPath` and/or `TrkAnaEndPath` appears. I know that this works for `TrkAnaExtracted.fcl` and `TrkAnaReco.fcl`. 

There is one case where I'm not sure if I'm handling things correctly, which is in `fcl/TrkAnaReco_wTrkQualFilter.fcl` where there are two trigger paths: `TrkAnaTrigPath` and `TrkAnaNegTrigPath`. 

Overall, I'm confident that this approach is correct for `TrkAnaExtracted.fcl` and `TrkAnaReco.fcl`, but I may need some advice for the others! 

-Sam

PS: Maybe an alternative approach would to create an `epilog.fcl`, where you define the trigger and end paths globally? 