### PR TITLE
Added trigger_paths and end_paths to TrkAnaExtracted.fcl and TrkAnaReco.fcl 

### DIFF
--- a/fcl/TrkAnaExtracted.fcl
+++ b/fcl/TrkAnaExtracted.fcl
@@ -19,6 +19,9 @@ physics :
 physics.TrkAnaTrigPath : [ @sequence::MergeKKNoFieldPath ]
 physics.TrkAnaEndPath : [ TrkAnaExt ]
 
+physics.trigger_paths : [ TrkAnaTrigPath ]
+physics.end_paths : [ TrkAnaEndPath ]
+
 # Include more information (MC, full TrkQual and TrkPID branches)
 physics.analyzers.TrkAnaExt.branches[0].options.fillMC : true
 physics.analyzers.TrkAnaExt.branches[0].options.genealogyDepth : 5

--- a/fcl/TrkAnaReco.fcl
+++ b/fcl/TrkAnaReco.fcl
@@ -21,6 +21,9 @@ physics :
 physics.TrkAnaTrigPath : [ @sequence::MergeKKProducersPath, PBIWeight, TrkQualDeM ]
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequence ]
 
+physics.trigger_paths : [ TrkAnaTrigPath ]
+physics.end_paths : [ TrkAnaEndPath ]
+
 # Include more information (MC, full TrkQual and TrkPID branches)
 # TODO: add these options back
 #physics.analyzers.TrkAnaNeg.candidate.options : @local::AllOpt


### PR DESCRIPTION
Referring to [TrkAna/issues/169](https://github.com/Mu2e/TrkAna/issues/169):

"Attempts to set up a grid submission using TrkAna fcl files with `mu2ejobdef` will result in an error relating to the fact that `physics.trigger_paths` and `physics.end_paths` are not defined."

I've added trigger_paths and end_paths to `TrkAnaExtracted.fcl` and `TrkAnaReco.fcl`. I know that this works for these files. 

There are cases where the best way to handle this is not clear to me, such in `TrkAnaReco_wTrkQualFilter.fcl` where there are two trigger paths (TrkAnaTrigPath and TrkAnaNegTrigPath), which is why I've limited this PR to the two files stated above. 

-Sam