### PR TITLE
Fix TrkAnaExtracted error 

### DIFF
--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -162,7 +162,7 @@ UmuP : { input : "MergeKKUmuP"
   branch : "ump"
   options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }
 }
-Ext : { input : "MergeKKExt"
+Ext : { input : "MergeKKLine"
   branch : "kl"
   options : { fillMC : true   genealogyDepth : -1 matchDepth : -1 }
 }


### PR DESCRIPTION
When I removed the "suffix" concept in #164, I didn't correct the configuration for TrkAnaExtracted.fcl correctly. This PR fixes that