### PR TITLE
Add old track fit parameters to LoopHelixInfo as a stopgap

### DIFF
--- a/inc/TrkInfo.hh
+++ b/inc/TrkInfo.hh
@@ -36,9 +36,11 @@ namespace mu2e
   };
 
   struct LoopHelixInfo {
-    // max radius (assuming geometric extrapolation).  This member is deprecated
+    //  These members are deprecated
     // in favor of explicit extrapolation to the OPA
-    float maxr = 0;
+    float maxr = 0; // max radius (assuming geometric extrapolation).
+    float d0 = 0; // d0 (unsigned!)
+    float tanDip = 0; // tanDip
     // loop helix parameters
     float rad=0,lam=0,cx=0,cy=0,phi0=0,t0=0;
     float raderr=0,lamerr=0,cxerr=0,cyerr=0,phi0err=0,t0err=0;

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -138,7 +138,9 @@ namespace mu2e {
       lhi.phi0err = sqrt(lh.paramVar(KinKal::LoopHelix::phi0_));
       lhi.t0err = sqrt(lh.paramVar(KinKal::LoopHelix::t0_));
       // deprecated!
-      lhi.maxr =sqrt(lh.cx()*lh.cx()+lh.cy()*lh.cy())+fabs(lh.rad());
+      lhi.maxr = lh.maxAxisDist();
+      lhi.d0 = lh.minAxisDist();
+      lhi.tanDip = 1.0/tan(lh.direction(lh.t0()).Theta());
       lhis.push_back(lhi);
     }
     all_lhis.push_back(lhis);


### PR DESCRIPTION
This PR adds back the old track parameters to the ```demlh``` branch: ```d0``` and ```tanDip```.

Note that the ```d0``` added here is unsigned. I don't think this is an issue because the most recent sensitivity update used the magnitude of the signed ```d0``` for a cut.

Also note that these are just a stopgap until we have proper physical variables that can be used in the analysis. I will add an issue so that we remove them at some point in the future