### PR TITLE
Updates so that we can run on data-only files

### DIFF
--- a/fcl/TrkAnaReco.fcl
+++ b/fcl/TrkAnaReco.fcl
@@ -17,7 +17,7 @@ physics :
   analyzers : { @table::TrkAnaReco.analyzers }
 }
 
-physics.TrkAnaTrigPath : [ @sequence::MergeKKProducersPath, PBIWeight, MakeSS, TrkQualDeM ]
+physics.TrkAnaTrigPath : [ @sequence::TrkAnaReco.TrigSequence ]
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequence ]
 
 physics.trigger_paths : [ TrkAnaTrigPath ]

--- a/fcl/TrkAnaRecoEnsemble-Data.fcl
+++ b/fcl/TrkAnaRecoEnsemble-Data.fcl
@@ -2,6 +2,7 @@
 
 physics.analyzers.TrkAna.FillMCInfo : false
 
+physics.TrkAnaTrigPath : [ @sequence::TrkAnaReco.TrigSequenceNoMC ]
 physics.TrkAnaEndPath : [ @sequence::TrkAnaReco.EndSequenceNoMC ]
 
 services.TFileService.fileName: "nts.owner.trkana-reco-ensemble-data.version.sequencer.root"

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -231,7 +231,9 @@ TrkAnaReco : {
     genCountLogger : @local::genCountLogger
   }
 
-  TrigSequence : [ PBIWeight, @sequence::TrkQualProducersPath, @sequence::TrkPIDProducersPath]
+  #  TrigSequence : [ PBIWeight, @sequence::TrkQualProducersPath, @sequence::TrkPIDProducersPath]
+  TrigSequence : [ @sequence::MergeKKProducersPath, PBIWeight, MakeSS, TrkQualDeM ]
+  TrigSequenceNoMC : [ @sequence::MergeKKProducersPath, TrkQualDeM ]
   EndSequenceNoMC : [ TrkAna ]
   EndSequence : [ TrkAna, genCountLogger ]
 

--- a/src/TrkAnaTreeMaker_module.cc
+++ b/src/TrkAnaTreeMaker_module.cc
@@ -404,7 +404,9 @@ namespace mu2e {
     _trkana=tfs->make<TTree>("trkana","track analysis");
     // add event info branch
     _trkana->Branch("evtinfo.",&_einfo,_buffsize,_splitlevel);
-    _trkana->Branch("evtinfomc.",&_einfomc,_buffsize,_splitlevel);
+    if (_fillmc) {
+      _trkana->Branch("evtinfomc.",&_einfomc,_buffsize,_splitlevel);
+    }
     // hit counting branch
     _trkana->Branch("hcnt.",&_hcnt);
     // track counting branches
@@ -701,13 +703,15 @@ namespace mu2e {
     _einfo.pbtime = PBT.pbtime_;
     _einfo.pbterr = PBT.pbterr_;
 
-    auto PBTMChandle = event.getValidHandle<mu2e::ProtonBunchTimeMC>(_PBTMCTag);
-    auto PBTMC = *PBTMChandle;
-    _einfomc.pbtime = PBTMC.pbtime_;
+    if (_fillmc) {
+      auto PBTMChandle = event.getValidHandle<mu2e::ProtonBunchTimeMC>(_PBTMCTag);
+      auto PBTMC = *PBTMChandle;
+      _einfomc.pbtime = PBTMC.pbtime_;
 
-    auto PBIhandle = event.getValidHandle<mu2e::ProtonBunchIntensity>(_PBITag);
-    auto PBI = *PBIhandle;
-    _einfomc.nprotons = PBI.intensity();
+      auto PBIhandle = event.getValidHandle<mu2e::ProtonBunchIntensity>(_PBITag);
+      auto PBI = *PBIhandle;
+      _einfomc.nprotons = PBI.intensity();
+    }
 
     // get event weight products
     std::vector<Float_t> weights;


### PR DESCRIPTION
This PR makes updates so that we can run on data-only files. This has been tested by using StripMC.fcl on an mcs ensemble file. Both TrkAnaReco.fcl and TrkAnaRecoEnsemble-Data.fcl work as expected