### PR TITLE
Update reflection script

### DIFF
--- a/fcl/from_mcs-reflection.fcl
+++ b/fcl/from_mcs-reflection.fcl
@@ -33,30 +33,39 @@ physics :
       @table::TrkQual
       KalSeedPtrCollection : Reflectmu
     }
+    TrkPIDReflecte : {
+      @table::TrkPID
+      KalSeedPtrCollection : Reflecte
+    }
+    TrkPIDReflectmu : {
+      @table::TrkPID
+      KalSeedPtrCollection : Reflectmu
+    }
   }
   filters : {
     Reflecte : {
       @table::TrkReco.SelectReflections
       UpstreamKalSeedCollection : "KKUe"
       DownstreamKalSeedCollection : "KKDe"
-      debugLevel : 0
+      debugLevel : 1
     }
     Reflectmu : {
       @table::TrkReco.SelectReflections
       UpstreamKalSeedCollection : "KKUmu"
       DownstreamKalSeedCollection : "KKDmu"
-      debugLevel : 0
+      debugLevel : 1
     }
   }
-  eTrig : [ Reflecte, TrkQualReflecte ]
-  muTrig : [ Reflectmu, TrkQualReflectmu ]
+  eTrig : [ Reflecte, TrkQualReflecte, TrkPIDReflecte ]
+  muTrig : [ Reflectmu, TrkQualReflectmu, TrkPIDReflectmu ]
   analyzers : {
     ENe : {
       @table::EN
       SelectEvents : [ "eTrig" ]
       branches : [
         { @table::ENBranch
-          trkQualTag : "TrkQualReflecte"
+          trkQualTags : ["TrkQualReflecte"]
+          trkPIDTags : ["TrkPIDReflecte"]
           input: "Reflecte"
         }
       ]
@@ -66,9 +75,11 @@ physics :
       SelectEvents : [ "muTrig" ]
       branches : [
         { @table::ENBranch
-          trkQualTag : "TrkQualReflectmu"
+          trkQualTags : ["TrkQualReflectmu"]
+          trkPIDTags : ["TrkPIDReflectmu"]
           input: "Reflectmu"
         }
+
       ]
     }
     printModule : {


### PR DESCRIPTION
Follow changes in core scripts.
Note that reflections allow validating the PID classification, as selecting on reflection DeltaT provides 99.9% pure e and mu samples.