### PR TITLE
Minor edits: Add a rooutil namespace and reduce some code duplication

### DIFF
--- a/rooutil/examples/CompareTrkQualTrainings.C
+++ b/rooutil/examples/CompareTrkQualTrainings.C
@@ -11,6 +11,8 @@
 #include "TLine.h"
 #include "TLatex.h"
 
+using namespace rooutil;
+
 void CompareTrkQualTrainings(std::string filename) {
 
   bool save_plots = false;

--- a/rooutil/examples/CreateNtuple.C
+++ b/rooutil/examples/CreateNtuple.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void CreateNtuple(std::string filename) {
 
   // Set up RooUtil

--- a/rooutil/examples/CreateTrackNtuple.C
+++ b/rooutil/examples/CreateTrackNtuple.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void CreateTrackNtuple(std::string filename) {
 
   // Create the TTree

--- a/rooutil/examples/PlotCRVPEs.C
+++ b/rooutil/examples/PlotCRVPEs.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotCRVPEs(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotCRVPEsVsMCEDep.C
+++ b/rooutil/examples/PlotCRVPEsVsMCEDep.C
@@ -8,6 +8,7 @@
 
 #include "TH2F.h"
 
+using namespace rooutil;
 void PlotCRVPEsVsMCEDep(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotCRVTotalPEs.C
+++ b/rooutil/examples/PlotCRVTotalPEs.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotCRVTotalPEs(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotCaloClusterEnergy.C
+++ b/rooutil/examples/PlotCaloClusterEnergy.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotCaloClusterEnergy(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotEntranceFitPars.C
+++ b/rooutil/examples/PlotEntranceFitPars.C
@@ -11,6 +11,7 @@
 #include "TEllipse.h"
 #include "TGaxis.h"
 
+using namespace rooutil;
 void PlotEntranceFitPars(std::string filename) {
 
   double xmin = -800;

--- a/rooutil/examples/PlotEntranceMomentum.C
+++ b/rooutil/examples/PlotEntranceMomentum.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotEntranceMomentum(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotEntranceMomentumCRVCut.C
+++ b/rooutil/examples/PlotEntranceMomentumCRVCut.C
@@ -9,6 +9,7 @@
 #include "TH1F.h"
 #include "TCanvas.h"
 
+using namespace rooutil;
 void PlotEntranceMomentumCRVCut(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotEntranceMomentumResolution.C
+++ b/rooutil/examples/PlotEntranceMomentumResolution.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotEntranceMomentumResolution(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotEntranceMomentumResolution_TrkQualCut.C
+++ b/rooutil/examples/PlotEntranceMomentumResolution_TrkQualCut.C
@@ -9,6 +9,7 @@
 #include "TH1F.h"
 #include "TCanvas.h"
 
+using namespace rooutil;
 void PlotEntranceMomentumResolution_TrkQualCut(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotEntranceMomentumTriggeredEvents.C
+++ b/rooutil/examples/PlotEntranceMomentumTriggeredEvents.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotEntranceMomentumTriggeredEvents(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotEntranceMomentum_UpstreamDownstream.C
+++ b/rooutil/examples/PlotEntranceMomentum_UpstreamDownstream.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotEntranceMomentum_UpstreamDownstream(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotEoverP_TrkPIDCut.C
+++ b/rooutil/examples/PlotEoverP_TrkPIDCut.C
@@ -9,6 +9,7 @@
 #include "TH1F.h"
 #include "TCanvas.h"
 
+using namespace rooutil;
 void PlotEoverP_TrkPIDCut(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotGenCosmicMom.C
+++ b/rooutil/examples/PlotGenCosmicMom.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotGenCosmicMom(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotMCParentPosZ.C
+++ b/rooutil/examples/PlotMCParentPosZ.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotMCParentPosZ(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotMCParticleMom.C
+++ b/rooutil/examples/PlotMCParticleMom.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotMCParticleMom(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotMuonPosZ.C
+++ b/rooutil/examples/PlotMuonPosZ.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotMuonPosZ(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotStoppingTargetFoilSegments.C
+++ b/rooutil/examples/PlotStoppingTargetFoilSegments.C
@@ -9,6 +9,7 @@
 #include "TH1F.h"
 #include "TLegend.h"
 
+using namespace rooutil;
 void PlotStoppingTargetFoilSegments(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotTrackHitCalibs.C
+++ b/rooutil/examples/PlotTrackHitCalibs.C
@@ -8,6 +8,7 @@
 
 #include "TH2F.h"
 
+using namespace rooutil;
 void PlotTrackHitCalibs(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotTrackHitTimes.C
+++ b/rooutil/examples/PlotTrackHitTimes.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotTrackHitTimes(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotTrackHitTimesMC.C
+++ b/rooutil/examples/PlotTrackHitTimesMC.C
@@ -10,6 +10,7 @@
 #include "TH2F.h"
 #include "TCanvas.h"
 
+using namespace rooutil;
 void PlotTrackHitTimesMC(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotTrackMaterials.C
+++ b/rooutil/examples/PlotTrackMaterials.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotTrackMaterials(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotTrackNHits_RecoVsTrue.C
+++ b/rooutil/examples/PlotTrackNHits_RecoVsTrue.C
@@ -8,6 +8,7 @@
 
 #include "TH2F.h"
 
+using namespace rooutil;
 void PlotTrackNHits_RecoVsTrue(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PlotTrkCaloHitEnergy.C
+++ b/rooutil/examples/PlotTrkCaloHitEnergy.C
@@ -8,6 +8,7 @@
 
 #include "TH1F.h"
 
+using namespace rooutil;
 void PlotTrkCaloHitEnergy(std::string filename) {
 
   // Create the histogram you want to fill

--- a/rooutil/examples/PrintEvents.C
+++ b/rooutil/examples/PrintEvents.C
@@ -6,6 +6,7 @@
 
 #include <iostream>
 
+using namespace rooutil;
 void PrintEvents(std::string filename) {
 
   RooUtil util(filename);

--- a/rooutil/examples/PrintEventsNoMC.C
+++ b/rooutil/examples/PrintEventsNoMC.C
@@ -3,6 +3,7 @@
 
 #include <iostream>
 
+using namespace rooutil;
 bool good_track(Track& track) {
   if (track.trk->fitcon > 1e-3 && is_e_minus(track)) {
     return true;

--- a/rooutil/examples/TimingTest.C
+++ b/rooutil/examples/TimingTest.C
@@ -7,6 +7,7 @@ using namespace std::chrono;
 #include "EventNtuple/rooutil/inc/RooUtil.hh"
 #include "EventNtuple/rooutil/inc/common_cuts.hh"
 
+using namespace rooutil;
 void TimingTest(std::string filename, bool log_output = false) {
 
   auto start_time = system_clock::now();

--- a/rooutil/examples/TrackCounting.C
+++ b/rooutil/examples/TrackCounting.C
@@ -3,6 +3,7 @@
 
 #include <iostream>
 
+using namespace rooutil;
 bool good_track(Track& track) {
   if (track.trk->fitcon > 1e-3) {
     return true;

--- a/rooutil/inc/CaloCluster.hh
+++ b/rooutil/inc/CaloCluster.hh
@@ -5,20 +5,21 @@
 #include "EventNtuple/inc/CaloClusterInfo.hh"
 #include "EventNtuple/inc/CaloHitInfo.hh"
 
-struct CaloCluster {
-  CaloCluster(mu2e::CaloClusterInfo* calocluster)
-    : calocluster(calocluster) {
+namespace rooutil {
+  struct CaloCluster {
+    CaloCluster(mu2e::CaloClusterInfo* calocluster)
+      : calocluster(calocluster) {
 
-  }
+    }
 
-  void Update(bool debug = false) {
-  }
+    void Update(bool debug = false) {
+    }
 
-  // Pointers to the data
-  mu2e::CaloClusterInfo* calocluster = nullptr;
-};
+    // Pointers to the data
+    mu2e::CaloClusterInfo* calocluster = nullptr;
+  };
 
-typedef std::function<bool(CaloCluster&)> CaloClusterCut;
-typedef std::vector<CaloCluster> CaloClusters;
-
+  typedef std::function<bool(CaloCluster&)> CaloClusterCut;
+  typedef std::vector<CaloCluster> CaloClusters;
+} // namespace rooutil
 #endif

--- a/rooutil/inc/CrvCoinc.hh
+++ b/rooutil/inc/CrvCoinc.hh
@@ -5,18 +5,19 @@
 #include "EventNtuple/inc/CrvHitInfoReco.hh"
 #include "EventNtuple/inc/CrvHitInfoMC.hh"
 
-struct CrvCoinc {
-  CrvCoinc(mu2e::CrvHitInfoReco* reco)
-    : reco(reco) {
+namespace rooutil {
+  struct CrvCoinc {
+    CrvCoinc(mu2e::CrvHitInfoReco* reco)
+      : reco(reco) {
 
-  }
+    }
 
-  // Pointers to the data
-  mu2e::CrvHitInfoReco* reco = nullptr;
-  mu2e::CrvHitInfoMC* mc = nullptr;
-};
+    // Pointers to the data
+    mu2e::CrvHitInfoReco* reco = nullptr;
+    mu2e::CrvHitInfoMC* mc = nullptr;
+  };
 
-typedef std::function<bool(CrvCoinc&)> CrvCoincCut;
-typedef std::vector<CrvCoinc> CrvCoincs;
-
+  typedef std::function<bool(CrvCoinc&)> CrvCoincCut;
+  typedef std::vector<CrvCoinc> CrvCoincs;
+} // namespace rooutil
 #endif

--- a/rooutil/inc/Event.hh
+++ b/rooutil/inc/Event.hh
@@ -44,295 +44,296 @@
 
 #include "TChain.h"
 
-struct Event {
-  Event(TChain* ntuple) {
-    CheckForBranch(ntuple, "evtinfo", &this->evtinfo);
-    CheckForBranch(ntuple, "hitcount", &this->hitcount);
-    CheckForBranch(ntuple, "crvsummary", &this->crvsummary);
-    const auto& branches = ntuple->GetListOfBranches();
-    int i_trig_branch = 0;
-    for (const auto& branch : *branches) {
-      std::string brname = branch->GetName();
-      if (brname.substr(0, 5) == "trig_") {
-        ntuple->SetBranchAddress(brname.c_str(), &this->triginfo._triggerArray[i_trig_branch]);
-        trigNameMap.insert({brname, i_trig_branch});
-        i_trig_branch++;
-      }
-    }
-
-    CheckForBranch(ntuple, "trk", &this->trk);
-    CheckForBranch(ntuple, "trksegs", &this->trksegs);
-    CheckForBranch(ntuple, "trkcalohit", &this->trkcalohit);
-    CheckForBranch(ntuple, "trkqual", &this->trkqual);
-    CheckForBranch(ntuple, "trkqual3", &this->trkqual_alt); // TODO: un-hardcode those
-    CheckForBranch(ntuple, "crvcoincs", &this->crvcoincs);
-    CheckForBranch(ntuple, "trkpid", &this->trkpid);
-
-    // Check if the MC branches exist
-    CheckForBranch(ntuple, "evtinfomc", &this->evtinfomc);
-    CheckForBranch(ntuple, "crvsummarymc", &this->crvsummarymc);
-    CheckForBranch(ntuple, "trkmc", &this->trkmc);
-    CheckForBranch(ntuple, "trksegsmc", &this->trksegsmc);
-    CheckForBranch(ntuple, "trksegpars_lh", &this->trksegpars_lh);
-    CheckForBranch(ntuple, "trksegpars_ch", &this->trksegpars_ch);
-    CheckForBranch(ntuple, "trksegpars_kl", &this->trksegpars_kl);
-    CheckForBranch(ntuple, "trkcalohitmc", &this->trkcalohitmc);
-    CheckForBranch(ntuple, "crvcoincsmc", &this->crvcoincsmc);
-    CheckForBranch(ntuple, "crvdigis", &this->crvdigis);
-    CheckForBranch(ntuple, "crvpulses", &this->crvpulses);
-    CheckForBranch(ntuple, "crvpulsesmc", &this->crvpulsesmc);
-    CheckForBranch(ntuple, "crvcoincsmcplane", &this->crvcoincsmcplane);
-    
-    CheckForBranch(ntuple, "trkmcsim", &this->trkmcsim);
-    CheckForBranch(ntuple, "trkhits", &this->trkhits);
-    CheckForBranch(ntuple, "trkhitsmc", &this->trkhitsmc);
-    CheckForBranch(ntuple, "trkmats", &this->trkmats);
-    CheckForBranch(ntuple, "trkhitcalibs", &this->trkhitcalibs);
-
-    CheckForBranch(ntuple, "caloclusters", &this->caloclusters);
-    CheckForBranch(ntuple, "calohits", &this->calohits);
-    CheckForBranch(ntuple, "calorecodigis", &this->calorecodigis);
-    CheckForBranch(ntuple, "calodigis", &this->calodigis);
-
-  }
-
-  // Check if a branch exists in the TChain, and optionally set its address
-  bool CheckForBranch(TChain* ntuple, const char* branch_name, void* address = nullptr) {
-    if(ntuple->GetBranch(branch_name) == nullptr || ntuple->GetBranchStatus(branch_name) == 0) return false;
-    if(address != nullptr) ntuple->SetBranchAddress(branch_name, address);
-    return true;
-  }
-
-  void Update(bool debug = false) {
-    if (debug) { std::cout << "Event::Update(): Clearing previous Tracks... " << std::endl; }
-    tracks.clear();
-    for (int i_track = 0; i_track < nTracks(); ++i_track) {
-      if (debug) { std::cout << "Event::Update(): Creating Track " << i_track << "... " << std::endl; }
-      Track track(&(trk->at(i_track)), &(trksegs->at(i_track)), &(trkcalohit->at(i_track))); // passing the addresses of the underlying structs
-      UpdateObject(track.trkmc, trkmc, i_track, debug);
-      UpdateObject(track.trksegsmc, trksegsmc, i_track, debug);
-      UpdateObject(track.trksegpars_lh, trksegpars_lh, i_track, debug);
-      UpdateObject(track.trksegpars_ch, trksegpars_ch, i_track, debug);
-      UpdateObject(track.trksegpars_kl, trksegpars_kl, i_track, debug);
-      UpdateObject(track.trkmcsim, trkmcsim, i_track, debug);
-      UpdateObject(track.trkhits, trkhits, i_track, debug);
-      UpdateObject(track.trkhitsmc, trkhitsmc, i_track, debug);
-      UpdateObject(track.trkmats, trkmats, i_track, debug);
-      UpdateObject(track.trkhitcalibs, trkhitcalibs, i_track, debug);
-      UpdateObject(track.trkqual, trkqual, i_track, debug);
-      UpdateObject(track.trkqual_alt, trkqual_alt, i_track, debug);
-      UpdateObject(track.trkpid, trkpid, i_track, debug);
-
-      if (debug) { std::cout << "Event::Update(): Updating Track " << i_track << "... " << std::endl; }
-      track.Update(debug);
-      if (debug) { std::cout << "Event::Update(): Adding Track " << i_track << " to Tracks... " << std::endl; }
-      tracks.emplace_back(track);
-    }
-
-    if (debug) { std::cout << "Event::Update(): Clearing previous CrvCoincs... " << std::endl; }
-    crv_coincs.clear();
-    for (int i_crv_coinc = 0; i_crv_coinc < nCrvCoincs(); ++i_crv_coinc) {
-      CrvCoinc crv_coinc(&(crvcoincs->at(i_crv_coinc)));
-      if (crvcoincsmc != nullptr) {
-        crv_coinc.mc = &(crvcoincsmc->at(i_crv_coinc));
-      }
-      crv_coincs.emplace_back(crv_coinc);
-    }
-
-    if (caloclusters != nullptr) {
-      if (debug) { std::cout << "Event::Update(): Clearing previous CaloClusters... " << std::endl; }
-      calo_clusters.clear();
-      for (int i_cluster = 0; i_cluster < nCaloClusters(); ++i_cluster) {
-        if (debug) { std::cout << "Event::Update(): Creating CaloCluster " << i_cluster << "... " << std::endl; }
-        CaloCluster calo_cluster(&(caloclusters->at(i_cluster))); // passing the addresses of the underlying structs
-        calo_clusters.emplace_back(calo_cluster);
-      }
-    }
-  }
-
-  template <typename T> void UpdateObject(T*& object, std::vector<T>* object_ptr, int index, bool debug = false) {
-    if (object_ptr != nullptr) {
-      if (debug) {
-        std::cout << "Event::Update(): Adding "
-                  << abi::__cxa_demangle(typeid(*object).name(), nullptr, nullptr, nullptr) << " to Track " << index << "... " << std::endl;
-      }
-      object = &(object_ptr->at(index));
-    } else if(debug) {
-      std::cout << "Event::Update(): No " << abi::__cxa_demangle(typeid(*object).name(), nullptr, nullptr, nullptr) << " to add to Track " << index << std::endl;
-    }
-  }
-
-  int nTracks() const {
-    if (trk == nullptr) { return 0; }
-    else { return trk->size(); }
-  }
-  int nCrvCoincs() const {
-    if (crvcoincs == nullptr) { return 0; }
-    else { return crvcoincs->size(); }
-  }
-  int nCaloClusters() const {
-    if (caloclusters == nullptr) { return 0; }
-    else { return caloclusters->size(); }
-  }
-
-
-  Tracks GetTracks() { return tracks; }
-  Tracks GetTracks(TrackCut cut, bool inplace = false) {
-    if (!inplace) { // if we are not changing inplace, then just create a new vector to return
-      Tracks select_tracks;
-      for (auto& track : tracks) {
-        if (cut(track)) {
-          select_tracks.emplace_back(track);
+namespace rooutil {
+  struct Event {
+    Event(TChain* ntuple) {
+      CheckForBranch(ntuple, "evtinfo", &this->evtinfo);
+      CheckForBranch(ntuple, "hitcount", &this->hitcount);
+      CheckForBranch(ntuple, "crvsummary", &this->crvsummary);
+      const auto& branches = ntuple->GetListOfBranches();
+      int i_trig_branch = 0;
+      for (const auto& branch : *branches) {
+        std::string brname = branch->GetName();
+        if (brname.substr(0, 5) == "trig_") {
+          ntuple->SetBranchAddress(brname.c_str(), &this->triginfo._triggerArray[i_trig_branch]);
+          trigNameMap.insert({brname, i_trig_branch});
+          i_trig_branch++;
         }
       }
-      return select_tracks;
-    }
-    else {
-      auto newEnd = std::remove_if(tracks.begin(), tracks.end(), [cut](Track& track) { return !cut(track); });
 
-      std::vector<size_t> trks_to_remove;
-      for (std::vector<Track>::iterator i_track = newEnd; i_track != tracks.end(); ++i_track) { // now need to remove from event
-        for (size_t i_trk = 0; i_trk < trk->size(); ++i_trk) {
-          if (&(trk->at(i_trk))  == i_track->trk) {
-            trks_to_remove.emplace_back(i_trk);
-            // flag i_trk for remoavel
+      CheckForBranch(ntuple, "trk", &this->trk);
+      CheckForBranch(ntuple, "trksegs", &this->trksegs);
+      CheckForBranch(ntuple, "trkcalohit", &this->trkcalohit);
+      CheckForBranch(ntuple, "trkqual", &this->trkqual);
+      CheckForBranch(ntuple, "trkqual3", &this->trkqual_alt); // TODO: un-hardcode those
+      CheckForBranch(ntuple, "crvcoincs", &this->crvcoincs);
+      CheckForBranch(ntuple, "trkpid", &this->trkpid);
+
+      // Check if the MC branches exist
+      CheckForBranch(ntuple, "evtinfomc", &this->evtinfomc);
+      CheckForBranch(ntuple, "crvsummarymc", &this->crvsummarymc);
+      CheckForBranch(ntuple, "trkmc", &this->trkmc);
+      CheckForBranch(ntuple, "trksegsmc", &this->trksegsmc);
+      CheckForBranch(ntuple, "trksegpars_lh", &this->trksegpars_lh);
+      CheckForBranch(ntuple, "trksegpars_ch", &this->trksegpars_ch);
+      CheckForBranch(ntuple, "trksegpars_kl", &this->trksegpars_kl);
+      CheckForBranch(ntuple, "trkcalohitmc", &this->trkcalohitmc);
+      CheckForBranch(ntuple, "crvcoincsmc", &this->crvcoincsmc);
+      CheckForBranch(ntuple, "crvdigis", &this->crvdigis);
+      CheckForBranch(ntuple, "crvpulses", &this->crvpulses);
+      CheckForBranch(ntuple, "crvpulsesmc", &this->crvpulsesmc);
+      CheckForBranch(ntuple, "crvcoincsmcplane", &this->crvcoincsmcplane);
+
+      CheckForBranch(ntuple, "trkmcsim", &this->trkmcsim);
+      CheckForBranch(ntuple, "trkhits", &this->trkhits);
+      CheckForBranch(ntuple, "trkhitsmc", &this->trkhitsmc);
+      CheckForBranch(ntuple, "trkmats", &this->trkmats);
+      CheckForBranch(ntuple, "trkhitcalibs", &this->trkhitcalibs);
+
+      CheckForBranch(ntuple, "caloclusters", &this->caloclusters);
+      CheckForBranch(ntuple, "calohits", &this->calohits);
+      CheckForBranch(ntuple, "calorecodigis", &this->calorecodigis);
+      CheckForBranch(ntuple, "calodigis", &this->calodigis);
+
+    }
+
+    // Check if a branch exists in the TChain, and optionally set its address
+    bool CheckForBranch(TChain* ntuple, const char* branch_name, void* address = nullptr) {
+      if(ntuple->GetBranch(branch_name) == nullptr || ntuple->GetBranchStatus(branch_name) == 0) return false;
+      if(address != nullptr) ntuple->SetBranchAddress(branch_name, address);
+      return true;
+    }
+
+    void Update(bool debug = false) {
+      if (debug) { std::cout << "Event::Update(): Clearing previous Tracks... " << std::endl; }
+      tracks.clear();
+      for (int i_track = 0; i_track < nTracks(); ++i_track) {
+        if (debug) { std::cout << "Event::Update(): Creating Track " << i_track << "... " << std::endl; }
+        Track track(&(trk->at(i_track)), &(trksegs->at(i_track)), &(trkcalohit->at(i_track))); // passing the addresses of the underlying structs
+        UpdateObject(track.trkmc, trkmc, i_track, debug);
+        UpdateObject(track.trksegsmc, trksegsmc, i_track, debug);
+        UpdateObject(track.trksegpars_lh, trksegpars_lh, i_track, debug);
+        UpdateObject(track.trksegpars_ch, trksegpars_ch, i_track, debug);
+        UpdateObject(track.trksegpars_kl, trksegpars_kl, i_track, debug);
+        UpdateObject(track.trkmcsim, trkmcsim, i_track, debug);
+        UpdateObject(track.trkhits, trkhits, i_track, debug);
+        UpdateObject(track.trkhitsmc, trkhitsmc, i_track, debug);
+        UpdateObject(track.trkmats, trkmats, i_track, debug);
+        UpdateObject(track.trkhitcalibs, trkhitcalibs, i_track, debug);
+        UpdateObject(track.trkqual, trkqual, i_track, debug);
+        UpdateObject(track.trkqual_alt, trkqual_alt, i_track, debug);
+        UpdateObject(track.trkpid, trkpid, i_track, debug);
+
+        if (debug) { std::cout << "Event::Update(): Updating Track " << i_track << "... " << std::endl; }
+        track.Update(debug);
+        if (debug) { std::cout << "Event::Update(): Adding Track " << i_track << " to Tracks... " << std::endl; }
+        tracks.emplace_back(track);
+      }
+
+      if (debug) { std::cout << "Event::Update(): Clearing previous CrvCoincs... " << std::endl; }
+      crv_coincs.clear();
+      for (int i_crv_coinc = 0; i_crv_coinc < nCrvCoincs(); ++i_crv_coinc) {
+        CrvCoinc crv_coinc(&(crvcoincs->at(i_crv_coinc)));
+        if (crvcoincsmc != nullptr) {
+          crv_coinc.mc = &(crvcoincsmc->at(i_crv_coinc));
+        }
+        crv_coincs.emplace_back(crv_coinc);
+      }
+
+      if (caloclusters != nullptr) {
+        if (debug) { std::cout << "Event::Update(): Clearing previous CaloClusters... " << std::endl; }
+        calo_clusters.clear();
+        for (int i_cluster = 0; i_cluster < nCaloClusters(); ++i_cluster) {
+          if (debug) { std::cout << "Event::Update(): Creating CaloCluster " << i_cluster << "... " << std::endl; }
+          CaloCluster calo_cluster(&(caloclusters->at(i_cluster))); // passing the addresses of the underlying structs
+          calo_clusters.emplace_back(calo_cluster);
+        }
+      }
+    }
+
+    template <typename T> void UpdateObject(T*& object, std::vector<T>* object_ptr, int index, bool debug = false) {
+      if (object_ptr != nullptr) {
+        if (debug) {
+          std::cout << "Event::Update(): Adding "
+                    << abi::__cxa_demangle(typeid(*object).name(), nullptr, nullptr, nullptr) << " to Track " << index << "... " << std::endl;
+        }
+        object = &(object_ptr->at(index));
+      } else if(debug) {
+        std::cout << "Event::Update(): No " << abi::__cxa_demangle(typeid(*object).name(), nullptr, nullptr, nullptr) << " to add to Track " << index << std::endl;
+      }
+    }
+
+    int nTracks() const {
+      if (trk == nullptr) { return 0; }
+      else { return trk->size(); }
+    }
+    int nCrvCoincs() const {
+      if (crvcoincs == nullptr) { return 0; }
+      else { return crvcoincs->size(); }
+    }
+    int nCaloClusters() const {
+      if (caloclusters == nullptr) { return 0; }
+      else { return caloclusters->size(); }
+    }
+
+
+    Tracks GetTracks() { return tracks; }
+    Tracks GetTracks(TrackCut cut, bool inplace = false) {
+      if (!inplace) { // if we are not changing inplace, then just create a new vector to return
+        Tracks select_tracks;
+        for (auto& track : tracks) {
+          if (cut(track)) {
+            select_tracks.emplace_back(track);
           }
         }
+        return select_tracks;
       }
-      for (int i_trk = trks_to_remove.size()-1; i_trk >= 0; --i_trk) {
-        trk->erase(trk->begin()+trks_to_remove[i_trk]);
-        if (trkmc) { trkmc->erase(trkmc->begin()+trks_to_remove[i_trk]); }
-        if (trksegs) { trksegs->erase(trksegs->begin()+trks_to_remove[i_trk]); }
-        if (trksegsmc) { trksegsmc->erase(trksegsmc->begin()+trks_to_remove[i_trk]); }
-        if (trkcalohit) { trkcalohit->erase(trkcalohit->begin()+trks_to_remove[i_trk]); }
-        if (trkqual) { trkqual->erase(trkqual->begin()+trks_to_remove[i_trk]); }
-        if (trkqual_alt) { trkqual_alt->erase(trkqual_alt->begin()+trks_to_remove[i_trk]); }
-        if (trkpid) { trkpid->erase(trkpid->begin()+trks_to_remove[i_trk]); }
-        if (trksegpars_lh) { trksegpars_lh->erase(trksegpars_lh->begin()+trks_to_remove[i_trk]); }
-        if (trksegpars_ch) { trksegpars_ch->erase(trksegpars_ch->begin()+trks_to_remove[i_trk]); }
-        if (trksegpars_kl) { trksegpars_kl->erase(trksegpars_kl->begin()+trks_to_remove[i_trk]); }
-        if (trkhits) { trkhits->erase(trkhits->begin()+trks_to_remove[i_trk]); }
-        if (trkhitsmc) { trkhitsmc->erase(trkhitsmc->begin()+trks_to_remove[i_trk]); }
-        if (trkmats) { trkmats->erase(trkmats->begin()+trks_to_remove[i_trk]); }
-        if (trkhitcalibs) { trkhitcalibs->erase(trkhitcalibs->begin()+trks_to_remove[i_trk]); }
-      }
+      else {
+        auto newEnd = std::remove_if(tracks.begin(), tracks.end(), [cut](Track& track) { return !cut(track); });
 
-      tracks.erase(newEnd, tracks.end()); // remove only rearranges and returns the new end
-      return tracks;
-    }
-  }
-
-  CrvCoincs GetCrvCoincs() { return crv_coincs; }
-  CrvCoincs GetCrvCoincs(CrvCoincCut cut) {
-    CrvCoincs select_crv_coincs;
-    for (auto& crv_coinc : crv_coincs) {
-      if (cut(crv_coinc)) {
-        select_crv_coincs.emplace_back(crv_coinc);
-      }
-    }
-    return select_crv_coincs;
-  }
-
-  CaloClusters GetCaloClusters() { return calo_clusters; }
-  CaloClusters GetCaloClusters(CaloClusterCut cut, bool inplace = false) {
-    if (!inplace) { // if we are not changing inplace, then just create a new vector to return
-      CaloClusters select_calo_clusters;
-      for (auto& calo_cluster : calo_clusters) {
-        if (cut(calo_cluster)) {
-          select_calo_clusters.emplace_back(calo_cluster);
-        }
-      }
-      return select_calo_clusters;
-    }
-    else {
-      auto newEnd = std::remove_if(calo_clusters.begin(), calo_clusters.end(), [cut](CaloCluster& calo_cluster) { return !cut(calo_cluster); });
-
-      std::vector<size_t> caloclusters_to_remove;
-      for (std::vector<CaloCluster>::iterator i_calo_cluster = newEnd; i_calo_cluster != calo_clusters.end(); ++i_calo_cluster) { // now need to remove from event
-        for (size_t i_calocluster = 0; i_calocluster < caloclusters->size(); ++i_calocluster) {
-          if (&(caloclusters->at(i_calocluster))  == i_calo_cluster->calocluster) {
-            caloclusters_to_remove.emplace_back(i_calocluster);
-            // flag i_calocluster for remoavel
+        std::vector<size_t> trks_to_remove;
+        for (std::vector<Track>::iterator i_track = newEnd; i_track != tracks.end(); ++i_track) { // now need to remove from event
+          for (size_t i_trk = 0; i_trk < trk->size(); ++i_trk) {
+            if (&(trk->at(i_trk))  == i_track->trk) {
+              trks_to_remove.emplace_back(i_trk);
+              // flag i_trk for remoavel
+            }
           }
         }
-      }
-      for (int i_calocluster = caloclusters_to_remove.size()-1; i_calocluster >= 0; --i_calocluster) {
-        caloclusters->erase(caloclusters->begin()+caloclusters_to_remove[i_calocluster]);
-      }
+        for (int i_trk = trks_to_remove.size()-1; i_trk >= 0; --i_trk) {
+          trk->erase(trk->begin()+trks_to_remove[i_trk]);
+          if (trkmc) { trkmc->erase(trkmc->begin()+trks_to_remove[i_trk]); }
+          if (trksegs) { trksegs->erase(trksegs->begin()+trks_to_remove[i_trk]); }
+          if (trksegsmc) { trksegsmc->erase(trksegsmc->begin()+trks_to_remove[i_trk]); }
+          if (trkcalohit) { trkcalohit->erase(trkcalohit->begin()+trks_to_remove[i_trk]); }
+          if (trkqual) { trkqual->erase(trkqual->begin()+trks_to_remove[i_trk]); }
+          if (trkqual_alt) { trkqual_alt->erase(trkqual_alt->begin()+trks_to_remove[i_trk]); }
+          if (trkpid) { trkpid->erase(trkpid->begin()+trks_to_remove[i_trk]); }
+          if (trksegpars_lh) { trksegpars_lh->erase(trksegpars_lh->begin()+trks_to_remove[i_trk]); }
+          if (trksegpars_ch) { trksegpars_ch->erase(trksegpars_ch->begin()+trks_to_remove[i_trk]); }
+          if (trksegpars_kl) { trksegpars_kl->erase(trksegpars_kl->begin()+trks_to_remove[i_trk]); }
+          if (trkhits) { trkhits->erase(trkhits->begin()+trks_to_remove[i_trk]); }
+          if (trkhitsmc) { trkhitsmc->erase(trkhitsmc->begin()+trks_to_remove[i_trk]); }
+          if (trkmats) { trkmats->erase(trkmats->begin()+trks_to_remove[i_trk]); }
+          if (trkhitcalibs) { trkhitcalibs->erase(trkhitcalibs->begin()+trks_to_remove[i_trk]); }
+        }
 
-      calo_clusters.erase(newEnd, calo_clusters.end()); // remove only rearranges and returns the new end
-      return calo_clusters;
+        tracks.erase(newEnd, tracks.end()); // remove only rearranges and returns the new end
+        return tracks;
+      }
     }
-  }
 
-  int CountTracks() { return tracks.size(); }
-  int CountTracks(TrackCut cut) {
-    Tracks select_tracks = GetTracks(cut);
-    return select_tracks.size();
-  }
+    CrvCoincs GetCrvCoincs() { return crv_coincs; }
+    CrvCoincs GetCrvCoincs(CrvCoincCut cut) {
+      CrvCoincs select_crv_coincs;
+      for (auto& crv_coinc : crv_coincs) {
+        if (cut(crv_coinc)) {
+          select_crv_coincs.emplace_back(crv_coinc);
+        }
+      }
+      return select_crv_coincs;
+    }
 
-  void SelectTracks(TrackCut cut) { // will reduce the tracks stored in the event
-    GetTracks(cut, true); // change in place
-  }
+    CaloClusters GetCaloClusters() { return calo_clusters; }
+    CaloClusters GetCaloClusters(CaloClusterCut cut, bool inplace = false) {
+      if (!inplace) { // if we are not changing inplace, then just create a new vector to return
+        CaloClusters select_calo_clusters;
+        for (auto& calo_cluster : calo_clusters) {
+          if (cut(calo_cluster)) {
+            select_calo_clusters.emplace_back(calo_cluster);
+          }
+        }
+        return select_calo_clusters;
+      }
+      else {
+        auto newEnd = std::remove_if(calo_clusters.begin(), calo_clusters.end(), [cut](CaloCluster& calo_cluster) { return !cut(calo_cluster); });
 
-  int CountCrvCoincs() { return crv_coincs.size(); }
-  int CountCrvCoincs(CrvCoincCut cut) {
-    CrvCoincs select_crv_coincs = GetCrvCoincs(cut);
-    return select_crv_coincs.size();
-  }
+        std::vector<size_t> caloclusters_to_remove;
+        for (std::vector<CaloCluster>::iterator i_calo_cluster = newEnd; i_calo_cluster != calo_clusters.end(); ++i_calo_cluster) { // now need to remove from event
+          for (size_t i_calocluster = 0; i_calocluster < caloclusters->size(); ++i_calocluster) {
+            if (&(caloclusters->at(i_calocluster))  == i_calo_cluster->calocluster) {
+              caloclusters_to_remove.emplace_back(i_calocluster);
+              // flag i_calocluster for remoavel
+            }
+          }
+        }
+        for (int i_calocluster = caloclusters_to_remove.size()-1; i_calocluster >= 0; --i_calocluster) {
+          caloclusters->erase(caloclusters->begin()+caloclusters_to_remove[i_calocluster]);
+        }
 
-  int CountCaloClusters() { return calo_clusters.size(); }
-  int CountCaloClusters(CaloClusterCut cut) {
-    CaloClusters select_calo_clusters = GetCaloClusters(cut);
-    return select_calo_clusters.size();
-  }
+        calo_clusters.erase(newEnd, calo_clusters.end()); // remove only rearranges and returns the new end
+        return calo_clusters;
+      }
+    }
+
+    int CountTracks() { return tracks.size(); }
+    int CountTracks(TrackCut cut) {
+      Tracks select_tracks = GetTracks(cut);
+      return select_tracks.size();
+    }
+
+    void SelectTracks(TrackCut cut) { // will reduce the tracks stored in the event
+      GetTracks(cut, true); // change in place
+    }
+
+    int CountCrvCoincs() { return crv_coincs.size(); }
+    int CountCrvCoincs(CrvCoincCut cut) {
+      CrvCoincs select_crv_coincs = GetCrvCoincs(cut);
+      return select_crv_coincs.size();
+    }
+
+    int CountCaloClusters() { return calo_clusters.size(); }
+    int CountCaloClusters(CaloClusterCut cut) {
+      CaloClusters select_calo_clusters = GetCaloClusters(cut);
+      return select_calo_clusters.size();
+    }
 
 
-  Tracks tracks;
-  CrvCoincs crv_coincs;
-  CaloClusters calo_clusters;
+    Tracks tracks;
+    CrvCoincs crv_coincs;
+    CaloClusters calo_clusters;
 
-  // Pointers to the data
-  mu2e::EventInfo* evtinfo = nullptr;
-  mu2e::EventInfoMC* evtinfomc = nullptr;
-  mu2e::HitCount* hitcount = nullptr;
-  mu2e::CrvSummaryReco* crvsummary = nullptr;
-  mu2e::CrvSummaryMC* crvsummarymc = nullptr;
-  mu2e::TrigInfo triginfo; // not a pointer because we give the address of array elements inside this
+    // Pointers to the data
+    mu2e::EventInfo* evtinfo = nullptr;
+    mu2e::EventInfoMC* evtinfomc = nullptr;
+    mu2e::HitCount* hitcount = nullptr;
+    mu2e::CrvSummaryReco* crvsummary = nullptr;
+    mu2e::CrvSummaryMC* crvsummarymc = nullptr;
+    mu2e::TrigInfo triginfo; // not a pointer because we give the address of array elements inside this
 
-  std::vector<mu2e::TrkInfo>* trk = nullptr;
-  std::vector<mu2e::TrkInfoMC>* trkmc = nullptr;
-  std::vector<mu2e::TrkCaloHitInfo>* trkcalohit = nullptr;
-  std::vector<mu2e::CaloClusterInfoMC>* trkcalohitmc = nullptr;
-  std::vector<mu2e::MVAResultInfo>* trkqual = nullptr;
-  std::vector<mu2e::MVAResultInfo>* trkqual_alt = nullptr; // an optional trkqual branch to also use
-  std::vector<mu2e::MVAResultInfo>* trkpid = nullptr;
-  std::vector<std::vector<mu2e::TrkSegInfo>>* trksegs = nullptr;
-  std::vector<std::vector<mu2e::SurfaceStepInfo>>* trksegsmc = nullptr;
-  std::vector<std::vector<mu2e::LoopHelixInfo>>* trksegpars_lh = nullptr;
-  std::vector<std::vector<mu2e::CentralHelixInfo>>* trksegpars_ch = nullptr;
-  std::vector<std::vector<mu2e::KinematicLineInfo>>* trksegpars_kl = nullptr;
-  std::vector<std::vector<mu2e::TrkStrawHitInfo>>* trkhits = nullptr;
-  std::vector<std::vector<mu2e::TrkStrawHitInfoMC>>* trkhitsmc = nullptr;
-  std::vector<std::vector<mu2e::TrkStrawMatInfo>>* trkmats = nullptr;
-  std::vector<std::vector<mu2e::TrkStrawHitCalibInfo>>* trkhitcalibs = nullptr;
+    std::vector<mu2e::TrkInfo>* trk = nullptr;
+    std::vector<mu2e::TrkInfoMC>* trkmc = nullptr;
+    std::vector<mu2e::TrkCaloHitInfo>* trkcalohit = nullptr;
+    std::vector<mu2e::CaloClusterInfoMC>* trkcalohitmc = nullptr;
+    std::vector<mu2e::MVAResultInfo>* trkqual = nullptr;
+    std::vector<mu2e::MVAResultInfo>* trkqual_alt = nullptr; // an optional trkqual branch to also use
+    std::vector<mu2e::MVAResultInfo>* trkpid = nullptr;
+    std::vector<std::vector<mu2e::TrkSegInfo>>* trksegs = nullptr;
+    std::vector<std::vector<mu2e::SurfaceStepInfo>>* trksegsmc = nullptr;
+    std::vector<std::vector<mu2e::LoopHelixInfo>>* trksegpars_lh = nullptr;
+    std::vector<std::vector<mu2e::CentralHelixInfo>>* trksegpars_ch = nullptr;
+    std::vector<std::vector<mu2e::KinematicLineInfo>>* trksegpars_kl = nullptr;
+    std::vector<std::vector<mu2e::TrkStrawHitInfo>>* trkhits = nullptr;
+    std::vector<std::vector<mu2e::TrkStrawHitInfoMC>>* trkhitsmc = nullptr;
+    std::vector<std::vector<mu2e::TrkStrawMatInfo>>* trkmats = nullptr;
+    std::vector<std::vector<mu2e::TrkStrawHitCalibInfo>>* trkhitcalibs = nullptr;
 
-  std::vector<mu2e::CaloClusterInfo>* caloclusters = nullptr;
-  std::vector<mu2e::CaloHitInfo>* calohits = nullptr;
-  std::vector<mu2e::CaloRecoDigiInfo>* calorecodigis = nullptr;
-  std::vector<mu2e::CaloDigiInfo>* calodigis = nullptr;
+    std::vector<mu2e::CaloClusterInfo>* caloclusters = nullptr;
+    std::vector<mu2e::CaloHitInfo>* calohits = nullptr;
+    std::vector<mu2e::CaloRecoDigiInfo>* calorecodigis = nullptr;
+    std::vector<mu2e::CaloDigiInfo>* calodigis = nullptr;
 
-  std::vector<mu2e::CrvHitInfoReco>* crvcoincs = nullptr;
-  std::vector<mu2e::CrvHitInfoMC>* crvcoincsmc = nullptr;
-  std::vector<mu2e::CrvWaveformInfo>* crvdigis = nullptr;
-  std::vector<mu2e::CrvPulseInfoReco>* crvpulses = nullptr;
-  std::vector<mu2e::CrvHitInfoMC>* crvpulsesmc = nullptr;
-  std::vector<mu2e::CrvPlaneInfoMC>* crvcoincsmcplane = nullptr;
+    std::vector<mu2e::CrvHitInfoReco>* crvcoincs = nullptr;
+    std::vector<mu2e::CrvHitInfoMC>* crvcoincsmc = nullptr;
+    std::vector<mu2e::CrvWaveformInfo>* crvdigis = nullptr;
+    std::vector<mu2e::CrvPulseInfoReco>* crvpulses = nullptr;
+    std::vector<mu2e::CrvHitInfoMC>* crvpulsesmc = nullptr;
+    std::vector<mu2e::CrvPlaneInfoMC>* crvcoincsmcplane = nullptr;
 
-  std::vector<std::vector<mu2e::SimInfo>>* trkmcsim = nullptr;
+    std::vector<std::vector<mu2e::SimInfo>>* trkmcsim = nullptr;
 
-  // Need to keep track of trigger name to element in triginfo
-  std::map<std::string, unsigned int> trigNameMap;
-};
-
+    // Need to keep track of trigger name to element in triginfo
+    std::map<std::string, unsigned int> trigNameMap;
+  };
+} // namespace rooutil
 #endif

--- a/rooutil/inc/MCParticle.hh
+++ b/rooutil/inc/MCParticle.hh
@@ -5,14 +5,15 @@
 #include "EventNtuple/inc/SimInfo.hh"
 #include "EventNtuple/inc/SurfaceStepInfo.hh"
 
-struct MCParticle {
-  MCParticle(mu2e::SimInfo* mcsim) : mcsim(mcsim) { }
+namespace rooutil {
+  struct MCParticle {
+    MCParticle(mu2e::SimInfo* mcsim) : mcsim(mcsim) { }
 
-  // Pointers to the data
-  mu2e::SimInfo* mcsim = nullptr;
-};
+    // Pointers to the data
+    mu2e::SimInfo* mcsim = nullptr;
+  };
 
-typedef std::function<bool(MCParticle&)> MCParticleCut;
-typedef std::vector<MCParticle> MCParticles;
-
+  typedef std::function<bool(MCParticle&)> MCParticleCut;
+  typedef std::vector<MCParticle> MCParticles;
+} // namespace rooutil
 #endif

--- a/rooutil/inc/RooUtil.hh
+++ b/rooutil/inc/RooUtil.hh
@@ -9,160 +9,161 @@
 
 #include "EventNtuple/rooutil/inc/Event.hh"
 
-class RooUtil {
-public:
-  RooUtil(std::string filename, bool debug = false, std::string treename = "EventNtuple/ntuple") : debug(debug) {
-    ntuple = new TChain(treename.c_str());
+namespace rooutil {
+  class RooUtil {
+  public:
+    RooUtil(std::string filename, bool debug = false, std::string treename = "EventNtuple/ntuple") : debug(debug) {
+      ntuple = new TChain(treename.c_str());
 
-    // Check if the given filename contains .root at the end
-    std::string root_suffix = ".root";
-    if (filename.compare(filename.size() - root_suffix.size(), root_suffix.size(), root_suffix) == 0) {
-      ntuple->Add(filename.c_str());
-      SetVersionNumber(filename);
-    }
-    else { //  assume its a file list
-      std::ifstream filelist(filename);
+      // Check if the given filename contains .root at the end
+      std::string root_suffix = ".root";
+      if (filename.compare(filename.size() - root_suffix.size(), root_suffix.size(), root_suffix) == 0) {
+        ntuple->Add(filename.c_str());
+        SetVersionNumber(filename);
+      }
+      else { //  assume its a file list
+        std::ifstream filelist(filename);
 
-      if (filelist.is_open()) {
-        std::string line;
-        bool first_line = true;
-        while (std::getline(filelist, line)) {
-          ntuple->Add(line.c_str());
+        if (filelist.is_open()) {
+          std::string line;
+          bool first_line = true;
+          while (std::getline(filelist, line)) {
+            ntuple->Add(line.c_str());
 
-          if (first_line) {
-            SetVersionNumber(line);
-            first_line = false;
+            if (first_line) {
+              SetVersionNumber(line);
+              first_line = false;
+            }
           }
+          filelist.close();
+        } else {
+          std::cout << "Error opening filelist." << std::endl;
         }
-        filelist.close();
-      } else {
-        std::cout << "Error opening filelist." << std::endl;
+      }
+
+      event = new Event(ntuple);
+    }
+
+    void Debug(bool dbg) { debug = dbg; }
+
+    void SetVersionNumber(std::string filename) {
+      TFile* file = new TFile(filename.c_str(), "READ");
+      TH1I* version = (TH1I*) file->Get("EventNtuple/version");
+      if (!version) {
+        std::cout << "Warning: this EventNtuple file does not contain a version number. It is either v06_02_00 or older. This is just a warning..." << std::endl;
+      }
+      else {
+        hVersion = (TH1I*) version->Clone();
+        hVersion->SetDirectory(0);
+        int majorVer = hVersion->GetBinContent(1);
+        int minorVer = hVersion->GetBinContent(2);
+        int patchVer = hVersion->GetBinContent(3);
+        std::cout << "EventNtuple v" << std::setw(2) << std::setfill('0') << majorVer << "_"
+                  << std::setw(2) << std::setfill('0') << minorVer << "_"
+                  << std::setw(2) << std::setfill('0') << patchVer << std::endl;
+      }
+      file->Close();
+      delete file;
+    }
+
+    int GetNEvents() { return ntuple->GetEntries(); }
+
+    Event& GetEvent(int i_event) {
+      if (debug) { std::cout << "RooUtil::GetEvent(): Getting event " << i_event << std::endl; }
+      ntuple->GetEntry(i_event);
+
+      if (debug) { std::cout << "RooUtil::GetEvent(): Updating event " << i_event << std::endl; }
+      event->Update(debug);
+
+      if (debug) { std::cout << "RooUtil::GetEvent(): Returning event " << i_event << std::endl; }
+      return *event;
+    }
+
+    void TurnOffBranch(const std::string& branchname) {
+      ntuple->SetBranchStatus(branchname.c_str(), 0);
+    }
+    void TurnOnBranch(const std::string& branchname) {
+      ntuple->SetBranchStatus(branchname.c_str(), 1);
+    }
+    void TurnOffBranches(const std::vector<std::string>& branchnames) {
+      for (const auto& branchname : branchnames) {
+        TurnOffBranch(branchname);
       }
     }
-
-    event = new Event(ntuple);
-  }
-
-  void Debug(bool dbg) { debug = dbg; }
-
-  void SetVersionNumber(std::string filename) {
-    TFile* file = new TFile(filename.c_str(), "READ");
-    TH1I* version = (TH1I*) file->Get("EventNtuple/version");
-    if (!version) {
-      std::cout << "Warning: this EventNtuple file does not contain a version number. It is either v06_02_00 or older. This is just a warning..." << std::endl;
+    void TurnOnBranches(const std::vector<std::string>& branchnames) {
+      for (const auto& branchname : branchnames) {
+        TurnOnBranch(branchname);
+      }
     }
-    else {
-      hVersion = (TH1I*) version->Clone();
-      hVersion->SetDirectory(0);
-      int majorVer = hVersion->GetBinContent(1);
-      int minorVer = hVersion->GetBinContent(2);
-      int patchVer = hVersion->GetBinContent(3);
-      std::cout << "EventNtuple v" << std::setw(2) << std::setfill('0') << majorVer << "_"
-                << std::setw(2) << std::setfill('0') << minorVer << "_"
-                << std::setw(2) << std::setfill('0') << patchVer << std::endl;
+    void TurnOffAllBranches() {
+      TurnOffBranch("*");
     }
-    file->Close();
-    delete file;
-  }
-
-  int GetNEvents() { return ntuple->GetEntries(); }
-
-  Event& GetEvent(int i_event) {
-    if (debug) { std::cout << "RooUtil::GetEvent(): Getting event " << i_event << std::endl; }
-    ntuple->GetEntry(i_event);
-
-    if (debug) { std::cout << "RooUtil::GetEvent(): Updating event " << i_event << std::endl; }
-    event->Update(debug);
-
-    if (debug) { std::cout << "RooUtil::GetEvent(): Returning event " << i_event << std::endl; }
-    return *event;
-  }
-
-  void TurnOffBranch(const std::string& branchname) {
-    ntuple->SetBranchStatus(branchname.c_str(), 0);
-  }
-  void TurnOnBranch(const std::string& branchname) {
-    ntuple->SetBranchStatus(branchname.c_str(), 1);
-  }
-  void TurnOffBranches(const std::vector<std::string>& branchnames) {
-    for (const auto& branchname : branchnames) {
-      TurnOffBranch(branchname);
-    }
-  }
-  void TurnOnBranches(const std::vector<std::string>& branchnames) {
-    for (const auto& branchname : branchnames) {
-      TurnOnBranch(branchname);
-    }
-  }
-  void TurnOffAllBranches() {
-    TurnOffBranch("*");
-  }
-  void TurnOnAllBranches() {
-    TurnOnBranch("*");
-  }
-
-  void CreateOutputEventNtuple(TFile* outfile) {
-    auto dir = outfile->mkdir("EventNtuple");
-    dir->cd();
-    output_ntuple = new TTree("ntuple", "reduced ntuple");
-
-    if(event->evtinfo) { output_ntuple->Branch("evtinfo", event->evtinfo); }
-    if(event->evtinfomc) { output_ntuple->Branch("evtinfomc", event->evtinfomc); }
-    if(event->hitcount) { output_ntuple->Branch("hitcount", event->hitcount); }
-    if(event->crvsummary) { output_ntuple->Branch("crvsummary", event->crvsummary); }
-    if(event->crvsummarymc) { output_ntuple->Branch("crvsummarymc", event->crvsummarymc); }
-
-    if(event->trk) { output_ntuple->Branch("trk", event->trk); }
-    if(event->trkmc) { output_ntuple->Branch("trkmc", event->trkmc); }
-    if(event->trkcalohit) { output_ntuple->Branch("trkcalohit", event->trkcalohit); }
-    if(event->trkcalohitmc) { output_ntuple->Branch("trkcalohitmc", event->trkcalohitmc); }
-    if(event->trkqual) { output_ntuple->Branch("trkqual", event->trkqual); }
-    if(event->trkqual_alt) { output_ntuple->Branch("trkqual_alt", event->trkqual_alt); }
-    if(event->trkpid) { output_ntuple->Branch("trkpid", event->trkpid); }
-    if(event->trksegs) { output_ntuple->Branch("trksegs", event->trksegs); }
-    if(event->trksegsmc) { output_ntuple->Branch("trksegsmc", event->trksegsmc); }
-    if(event->trksegpars_lh) { output_ntuple->Branch("trksegpars_lh", event->trksegpars_lh); }
-    if(event->trksegpars_ch) { output_ntuple->Branch("trksegpars_ch", event->trksegpars_ch); }
-    if(event->trksegpars_kl) { output_ntuple->Branch("trksegpars_kl", event->trksegpars_kl); }
-    if(event->trkhits) { output_ntuple->Branch("trkhits", event->trkhits); }
-    if(event->trkhitsmc) { output_ntuple->Branch("trkhitsmc", event->trkhitsmc); }
-    if(event->trkmats) { output_ntuple->Branch("trkmats", event->trkmats); }
-    if(event->trkhitcalibs) { output_ntuple->Branch("trkhitcalibs", event->trkhitcalibs); }
-
-    if(event->caloclusters) { output_ntuple->Branch("caloclusters", event->caloclusters); }
-    if(event->calohits) { output_ntuple->Branch("calohits", event->calohits); }
-    if(event->calorecodigis) { output_ntuple->Branch("calorecodigis", event->calorecodigis); }
-    if(event->calodigis) { output_ntuple->Branch("calodigis", event->calodigis); }
-
-    if(event->crvcoincs) { output_ntuple->Branch("crvcoincs", event->crvcoincs); }
-    if(event->crvcoincsmc) { output_ntuple->Branch("crvcoincsmc", event->crvcoincsmc); }
-    if(event->crvdigis) { output_ntuple->Branch("crvdigis", event->crvdigis); }
-    if(event->crvpulses) { output_ntuple->Branch("crvpulses", event->crvpulses); }
-    if(event->crvpulsesmc) { output_ntuple->Branch("crvpulsesmc", event->crvpulsesmc); }
-    if(event->crvcoincsmcplane) { output_ntuple->Branch("crvcoincsmcplane", event->crvcoincsmcplane); }
-
-    if(event->trkmcsim) { output_ntuple->Branch("trkmcsim", event->trkmcsim); }
-
-    for (const auto& pair : event->trigNameMap) {
-      output_ntuple->Branch(pair.first.c_str(), &event->triginfo._triggerArray[pair.second]);
+    void TurnOnAllBranches() {
+      TurnOnBranch("*");
     }
 
-    // Write out histograms from input to output
-    hVersion->Write();
-  }
+    void CreateOutputEventNtuple(TFile* outfile) {
+      auto dir = outfile->mkdir("EventNtuple");
+      dir->cd();
+      output_ntuple = new TTree("ntuple", "reduced ntuple");
 
-  void FillOutputEventNtuple() {
-    output_ntuple->Fill();
-  }
+      if(event->evtinfo) { output_ntuple->Branch("evtinfo", event->evtinfo); }
+      if(event->evtinfomc) { output_ntuple->Branch("evtinfomc", event->evtinfomc); }
+      if(event->hitcount) { output_ntuple->Branch("hitcount", event->hitcount); }
+      if(event->crvsummary) { output_ntuple->Branch("crvsummary", event->crvsummary); }
+      if(event->crvsummarymc) { output_ntuple->Branch("crvsummarymc", event->crvsummarymc); }
 
-private:
-  TChain* ntuple;
-  Event* event; // holds all the variables for SetBranchAddress
-  bool debug;
+      if(event->trk) { output_ntuple->Branch("trk", event->trk); }
+      if(event->trkmc) { output_ntuple->Branch("trkmc", event->trkmc); }
+      if(event->trkcalohit) { output_ntuple->Branch("trkcalohit", event->trkcalohit); }
+      if(event->trkcalohitmc) { output_ntuple->Branch("trkcalohitmc", event->trkcalohitmc); }
+      if(event->trkqual) { output_ntuple->Branch("trkqual", event->trkqual); }
+      if(event->trkqual_alt) { output_ntuple->Branch("trkqual_alt", event->trkqual_alt); }
+      if(event->trkpid) { output_ntuple->Branch("trkpid", event->trkpid); }
+      if(event->trksegs) { output_ntuple->Branch("trksegs", event->trksegs); }
+      if(event->trksegsmc) { output_ntuple->Branch("trksegsmc", event->trksegsmc); }
+      if(event->trksegpars_lh) { output_ntuple->Branch("trksegpars_lh", event->trksegpars_lh); }
+      if(event->trksegpars_ch) { output_ntuple->Branch("trksegpars_ch", event->trksegpars_ch); }
+      if(event->trksegpars_kl) { output_ntuple->Branch("trksegpars_kl", event->trksegpars_kl); }
+      if(event->trkhits) { output_ntuple->Branch("trkhits", event->trkhits); }
+      if(event->trkhitsmc) { output_ntuple->Branch("trkhitsmc", event->trkhitsmc); }
+      if(event->trkmats) { output_ntuple->Branch("trkmats", event->trkmats); }
+      if(event->trkhitcalibs) { output_ntuple->Branch("trkhitcalibs", event->trkhitcalibs); }
 
-  TH1I* hVersion;
+      if(event->caloclusters) { output_ntuple->Branch("caloclusters", event->caloclusters); }
+      if(event->calohits) { output_ntuple->Branch("calohits", event->calohits); }
+      if(event->calorecodigis) { output_ntuple->Branch("calorecodigis", event->calorecodigis); }
+      if(event->calodigis) { output_ntuple->Branch("calodigis", event->calodigis); }
 
-  TTree* output_ntuple; // for output
-};
+      if(event->crvcoincs) { output_ntuple->Branch("crvcoincs", event->crvcoincs); }
+      if(event->crvcoincsmc) { output_ntuple->Branch("crvcoincsmc", event->crvcoincsmc); }
+      if(event->crvdigis) { output_ntuple->Branch("crvdigis", event->crvdigis); }
+      if(event->crvpulses) { output_ntuple->Branch("crvpulses", event->crvpulses); }
+      if(event->crvpulsesmc) { output_ntuple->Branch("crvpulsesmc", event->crvpulsesmc); }
+      if(event->crvcoincsmcplane) { output_ntuple->Branch("crvcoincsmcplane", event->crvcoincsmcplane); }
 
+      if(event->trkmcsim) { output_ntuple->Branch("trkmcsim", event->trkmcsim); }
+
+      for (const auto& pair : event->trigNameMap) {
+        output_ntuple->Branch(pair.first.c_str(), &event->triginfo._triggerArray[pair.second]);
+      }
+
+      // Write out histograms from input to output
+      hVersion->Write();
+    }
+
+    void FillOutputEventNtuple() {
+      output_ntuple->Fill();
+    }
+
+  private:
+    TChain* ntuple;
+    Event* event; // holds all the variables for SetBranchAddress
+    bool debug;
+
+    TH1I* hVersion;
+
+    TTree* output_ntuple; // for output
+  };
+} // namespace rooutil
 #endif

--- a/rooutil/inc/Track.hh
+++ b/rooutil/inc/Track.hh
@@ -3,184 +3,195 @@
 
 #include <functional>
 #include "EventNtuple/inc/TrkInfo.hh"
+#include "EventNtuple/inc/TrkInfoMC.hh"
+#include "EventNtuple/inc/SurfaceStepInfo.hh"
+#include "EventNtuple/inc/LoopHelixInfo.hh"
+#include "EventNtuple/inc/CentralHelixInfo.hh"
+#include "EventNtuple/inc/KinematicLineInfo.hh"
+#include "EventNtuple/inc/TrkStrawHitInfo.hh"
+#include "EventNtuple/inc/TrkStrawHitInfoMC.hh"
+#include "EventNtuple/inc/TrkStrawMatInfo.hh"
 #include "EventNtuple/inc/TrkSegInfo.hh"
 #include "EventNtuple/inc/TrkCaloHitInfo.hh"
+#include "EventNtuple/inc/SimInfo.hh"
+#include "EventNtuple/inc/MVAResultInfo.hh"
 
 #include "EventNtuple/rooutil/inc/TrackSegment.hh"
 #include "EventNtuple/rooutil/inc/MCParticle.hh"
 #include "EventNtuple/rooutil/inc/TrackHit.hh"
-
-struct Track {
-  Track(mu2e::TrkInfo* trk, std::vector<mu2e::TrkSegInfo>* trksegs, mu2e::TrkCaloHitInfo* trkcalohit)
-    : trk(trk), trksegs(trksegs), trkcalohit(trkcalohit) {
-
-    // Create the underlying track segments
-    for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
-      TrackSegment segment(&(trksegs->at(i_segment))); // passing the addresses of the underlying structs
-      segments.emplace_back(segment);
+  
+namespace rooutil {
+  struct Track {
+    Track(mu2e::TrkInfo* trk, std::vector<mu2e::TrkSegInfo>* trksegs, mu2e::TrkCaloHitInfo* trkcalohit)
+      : trk(trk), trksegs(trksegs), trkcalohit(trkcalohit) {
+  
+      // Create the underlying track segments
+      for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
+        TrackSegment segment(&(trksegs->at(i_segment))); // passing the addresses of the underlying structs
+        segments.emplace_back(segment);
+      }
     }
-  }
-
-  void Update(bool debug = false) {
-    if (trksegsmc != nullptr) { // if we have MC information
-      // search for corresponding SurfaceStepInfo (it will have the same sid and sindex)
-      // also, trksegs and trksegms may not be the same length...
-      if (debug) { std::cout << "Track::Update(): Updating trksegsmc..." << std::endl; }
-      for (size_t i_segment_mc = 0; i_segment_mc < trksegsmc->size(); ++i_segment_mc) {
-        if (debug) { std::cout << "Track::Update(): Looking for trkseg to match trksegmc " << i_segment_mc << ".(of " << trksegsmc->size() << ").. "; }
-        bool reco_step_found = false;
-        double min_dt = 999999;
-        double max_dt = 5; // want to be at least this close
-        for (auto& segment : segments) {
-          if (segment.trkseg != nullptr) { // we might have added MC-only segments...
-
-            // Want to to match segments that are at the same surface (+ index) travelling in the same direction and closest in time
-            double dt = std::fabs(segment.trkseg->time - trksegsmc->at(i_segment_mc).time);
-            if (segment.trkseg->sid == trksegsmc->at(i_segment_mc).sid
-                && segment.trkseg->sindex == trksegsmc->at(i_segment_mc).sindex
-                && segment.trkseg->mom.Dot(trksegsmc->at(i_segment_mc).mom)>0
-                && dt < max_dt) {
-
-              if (dt < min_dt) {
-                min_dt = dt;
-                segment.trksegmc = &(trksegsmc->at(i_segment_mc));
-                reco_step_found = true;
-                if (debug) { std::cout << "FOUND (reco step mom = " << segment.trkseg->mom.R() << ", MC step mom = " << segment.trksegmc->mom.R() << ", dt = " << dt << ")" << std::endl; }
+  
+    void Update(bool debug = false) {
+      if (trksegsmc != nullptr) { // if we have MC information
+        // search for corresponding SurfaceStepInfo (it will have the same sid and sindex)
+        // also, trksegs and trksegms may not be the same length...
+        if (debug) { std::cout << "Track::Update(): Updating trksegsmc..." << std::endl; }
+        for (size_t i_segment_mc = 0; i_segment_mc < trksegsmc->size(); ++i_segment_mc) {
+          if (debug) { std::cout << "Track::Update(): Looking for trkseg to match trksegmc " << i_segment_mc << ".(of " << trksegsmc->size() << ").. "; }
+          bool reco_step_found = false;
+          double min_dt = 999999;
+          double max_dt = 5; // want to be at least this close
+          for (auto& segment : segments) {
+            if (segment.trkseg != nullptr) { // we might have added MC-only segments...
+  
+              // Want to to match segments that are at the same surface (+ index) travelling in the same direction and closest in time
+              double dt = std::fabs(segment.trkseg->time - trksegsmc->at(i_segment_mc).time);
+              if (segment.trkseg->sid == trksegsmc->at(i_segment_mc).sid
+                  && segment.trkseg->sindex == trksegsmc->at(i_segment_mc).sindex
+                  && segment.trkseg->mom.Dot(trksegsmc->at(i_segment_mc).mom)>0
+                  && dt < max_dt) {
+  
+                if (dt < min_dt) {
+                  min_dt = dt;
+                  segment.trksegmc = &(trksegsmc->at(i_segment_mc));
+                  reco_step_found = true;
+                  if (debug) { std::cout << "FOUND (reco step mom = " << segment.trkseg->mom.R() << ", MC step mom = " << segment.trksegmc->mom.R() << ", dt = " << dt << ")" << std::endl; }
+                }
               }
             }
           }
+          if (!reco_step_found) {
+            if (debug) { std::cout << "NOT FOUND. Adding MC-only TrackSegment..." << std::endl; }
+            TrackSegment segment_mc;
+            segment_mc.trksegmc = &(trksegsmc->at(i_segment_mc));
+            segments.emplace_back(segment_mc);
+          }
         }
-        if (!reco_step_found) {
-          if (debug) { std::cout << "NOT FOUND. Adding MC-only TrackSegment..." << std::endl; }
-          TrackSegment segment_mc;
-          segment_mc.trksegmc = &(trksegsmc->at(i_segment_mc));
-          segments.emplace_back(segment_mc);
+      }
+  
+      if (trkmcsim != nullptr) {
+        if (debug) { std::cout << "Track::Update(): Updating trkmcsim..." << std::endl; }
+        // Create the underlying MCParticles if possible
+        for (int i_mc_particle = 0; i_mc_particle < nMCParticles(); ++i_mc_particle) {
+          if (debug) { std::cout << "Track::Update(): Creating MCParticle " << i_mc_particle << " / " << nMCParticles() << "..." << std::endl; }
+          MCParticle mc_particle(&(trkmcsim->at(i_mc_particle))); // passing the addresses of the underlying structs
+          mc_particles.emplace_back(mc_particle);
         }
       }
-    }
-
-    if (trkmcsim != nullptr) {
-      if (debug) { std::cout << "Track::Update(): Updating trkmcsim..." << std::endl; }
-      // Create the underlying MCParticles if possible
-      for (int i_mc_particle = 0; i_mc_particle < nMCParticles(); ++i_mc_particle) {
-        if (debug) { std::cout << "Track::Update(): Creating MCParticle " << i_mc_particle << " / " << nMCParticles() << "..." << std::endl; }
-        MCParticle mc_particle(&(trkmcsim->at(i_mc_particle))); // passing the addresses of the underlying structs
-        mc_particles.emplace_back(mc_particle);
-      }
-    }
-
-    if (trksegpars_lh != nullptr) { // if we LoopHelix info
-      if (debug) { std::cout << "Track::Update(): Updating trksegpars_lh..." << std::endl; }
-      for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
-        segments[i_segment].trksegpars_lh = &(trksegpars_lh->at(i_segment));
-      }
-    }
-    if (trksegpars_ch != nullptr) { // if we CentralHelix info
-      if (debug) { std::cout << "Track::Update(): Updating trksegpars_ch..." << std::endl; }
-      for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
-        segments[i_segment].trksegpars_ch = &(trksegpars_ch->at(i_segment));
-      }
-    }
-    if (trksegpars_kl != nullptr) { // if we CentralHelix info
-      if (debug) { std::cout << "Track::Update(): Updating trksegpars_kl..." << std::endl; }
-      for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
-        segments[i_segment].trksegpars_kl = &(trksegpars_kl->at(i_segment));
-      }
-    }
-
-    if (trkhits != nullptr) {
-      if (debug) { std::cout << "Track::Update(): Updating trkhits..." << std::endl; }
-      // Create the underlying TrackHits
-      for (int i_trkhit = 0; i_trkhit < nHits(); ++i_trkhit) {
-        TrackHit trkhit;
-        trkhit.reco = &(trkhits->at(i_trkhit)); // passing the addresses of the underlying structs
-
-        // the first trkhitsmc correspond 1:1 with the reco hits, the remaining trkhitsmc also go with the truth
-        if (trkhitsmc != nullptr) {
-          trkhit.mc = &(trkhitsmc->at(i_trkhit));
+  
+      if (trksegpars_lh != nullptr) { // if we LoopHelix info
+        if (debug) { std::cout << "Track::Update(): Updating trksegpars_lh..." << std::endl; }
+        for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
+          segments[i_segment].trksegpars_lh = &(trksegpars_lh->at(i_segment));
         }
-
-        // trkhitcalibs have 1:1 correspondance with reco hits
-        if (trkhitcalibs != nullptr) {
-          trkhit.calib = &(trkhitcalibs->at(i_trkhit));
-        }
-
-        hits.emplace_back(trkhit);
       }
-      if (trkhitsmc != nullptr) {
-        if (debug) { std::cout << "Track::Update(): Updating trkhitsmc..." << std::endl; }
-        // Fill in the remainder of the track hits
-        for (size_t i_trkhitmc = nHits(); i_trkhitmc < trkhitsmc->size(); ++i_trkhitmc) {
+      if (trksegpars_ch != nullptr) { // if we CentralHelix info
+        if (debug) { std::cout << "Track::Update(): Updating trksegpars_ch..." << std::endl; }
+        for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
+          segments[i_segment].trksegpars_ch = &(trksegpars_ch->at(i_segment));
+        }
+      }
+      if (trksegpars_kl != nullptr) { // if we CentralHelix info
+        if (debug) { std::cout << "Track::Update(): Updating trksegpars_kl..." << std::endl; }
+        for (int i_segment = 0; i_segment < nSegments(); ++i_segment) {
+          segments[i_segment].trksegpars_kl = &(trksegpars_kl->at(i_segment));
+        }
+      }
+  
+      if (trkhits != nullptr) {
+        if (debug) { std::cout << "Track::Update(): Updating trkhits..." << std::endl; }
+        // Create the underlying TrackHits
+        for (int i_trkhit = 0; i_trkhit < nHits(); ++i_trkhit) {
           TrackHit trkhit;
-          trkhit.mc = &(trkhitsmc->at(i_trkhitmc));
+          trkhit.reco = &(trkhits->at(i_trkhit)); // passing the addresses of the underlying structs
+  
+          // the first trkhitsmc correspond 1:1 with the reco hits, the remaining trkhitsmc also go with the truth
+          if (trkhitsmc != nullptr) {
+            trkhit.mc = &(trkhitsmc->at(i_trkhit));
+          }
+  
+          // trkhitcalibs have 1:1 correspondance with reco hits
+          if (trkhitcalibs != nullptr) {
+            trkhit.calib = &(trkhitcalibs->at(i_trkhit));
+          }
+  
           hits.emplace_back(trkhit);
         }
+        if (trkhitsmc != nullptr) {
+          if (debug) { std::cout << "Track::Update(): Updating trkhitsmc..." << std::endl; }
+          // Fill in the remainder of the track hits
+          for (size_t i_trkhitmc = nHits(); i_trkhitmc < trkhitsmc->size(); ++i_trkhitmc) {
+            TrackHit trkhit;
+            trkhit.mc = &(trkhitsmc->at(i_trkhitmc));
+            hits.emplace_back(trkhit);
+          }
+        }
       }
     }
-  }
-
-  int nSegments() const { return trksegs->size(); }
-  TrackSegments GetSegments() { return segments; }
-  TrackSegments GetSegments(TrackSegmentCut cut) {
-    TrackSegments select_segments;
-    for (auto& segment : segments) {
-      if (cut(segment)) {
-        select_segments.emplace_back(segment);
+  
+    int nSegments() const { return trksegs->size(); }
+    TrackSegments GetSegments() { return segments; }
+    TrackSegments GetSegments(TrackSegmentCut cut) {
+      TrackSegments select_segments;
+      for (auto& segment : segments) {
+        if (cut(segment)) {
+          select_segments.emplace_back(segment);
+        }
       }
+      return select_segments;
     }
-    return select_segments;
-  }
-  TrackSegments segments;
-
-  int nMCParticles() const {
-    if (trkmcsim == nullptr) { return 0; }
-    else { return trkmcsim->size(); }
-  }
-  MCParticles GetMCParticles() { return mc_particles; }
-  MCParticles GetMCParticles(MCParticleCut cut) {
-    MCParticles select_mc_particles;
-    for (auto& mc_particle : mc_particles) {
-      if (cut(mc_particle)) {
-        select_mc_particles.emplace_back(mc_particle);
+    TrackSegments segments;
+  
+    int nMCParticles() const {
+      if (trkmcsim == nullptr) { return 0; }
+      else { return trkmcsim->size(); }
+    }
+    MCParticles GetMCParticles() { return mc_particles; }
+    MCParticles GetMCParticles(MCParticleCut cut) {
+      MCParticles select_mc_particles;
+      for (auto& mc_particle : mc_particles) {
+        if (cut(mc_particle)) {
+          select_mc_particles.emplace_back(mc_particle);
+        }
       }
+      return select_mc_particles;
     }
-    return select_mc_particles;
-  }
-  MCParticles mc_particles;
-
-  int nHits() const { return trkhits->size(); }
-  TrackHits GetHits() { return hits; }
-  TrackHits GetHits(TrackHitCut cut) {
-    TrackHits select_hits;
-    for (auto& hit : hits) {
-      if (cut(hit)) {
-        select_hits.emplace_back(hit);
+    MCParticles mc_particles;
+  
+    int nHits() const { return trkhits->size(); }
+    TrackHits GetHits() { return hits; }
+    TrackHits GetHits(TrackHitCut cut) {
+      TrackHits select_hits;
+      for (auto& hit : hits) {
+        if (cut(hit)) {
+          select_hits.emplace_back(hit);
+        }
       }
+      return select_hits;
     }
-    return select_hits;
-  }
-  TrackHits hits;
-
-  // Pointers to the data
-  mu2e::TrkInfo* trk = nullptr;
-  mu2e::TrkInfoMC* trkmc = nullptr;
-  std::vector<mu2e::TrkSegInfo>* trksegs = nullptr;
-  std::vector<mu2e::SurfaceStepInfo>* trksegsmc = nullptr;
-  std::vector<mu2e::LoopHelixInfo>* trksegpars_lh = nullptr;
-  std::vector<mu2e::CentralHelixInfo>* trksegpars_ch = nullptr;
-  std::vector<mu2e::KinematicLineInfo>* trksegpars_kl = nullptr;
-  std::vector<mu2e::TrkStrawHitInfo>* trkhits = nullptr;
-  std::vector<mu2e::TrkStrawHitInfoMC>* trkhitsmc = nullptr;
-  std::vector<mu2e::TrkStrawMatInfo>* trkmats = nullptr;
-  std::vector<mu2e::TrkStrawHitCalibInfo>* trkhitcalibs = nullptr;
-  mu2e::TrkCaloHitInfo* trkcalohit = nullptr;
-  std::vector<mu2e::SimInfo>* trkmcsim = nullptr;
-  mu2e::MVAResultInfo* trkqual = nullptr;
-  mu2e::MVAResultInfo* trkqual_alt = nullptr; // TODO: is there a way to allow for more than two...
-  mu2e::MVAResultInfo* trkpid = nullptr;
-};
-
-typedef std::function<bool(Track&)> TrackCut;
-typedef std::vector<Track> Tracks;
-
+    TrackHits hits;
+  
+    // Pointers to the data
+    mu2e::TrkInfo* trk = nullptr;
+    mu2e::TrkInfoMC* trkmc = nullptr;
+    std::vector<mu2e::TrkSegInfo>* trksegs = nullptr;
+    std::vector<mu2e::SurfaceStepInfo>* trksegsmc = nullptr;
+    std::vector<mu2e::LoopHelixInfo>* trksegpars_lh = nullptr;
+    std::vector<mu2e::CentralHelixInfo>* trksegpars_ch = nullptr;
+    std::vector<mu2e::KinematicLineInfo>* trksegpars_kl = nullptr;
+    std::vector<mu2e::TrkStrawHitInfo>* trkhits = nullptr;
+    std::vector<mu2e::TrkStrawHitInfoMC>* trkhitsmc = nullptr;
+    std::vector<mu2e::TrkStrawMatInfo>* trkmats = nullptr;
+    std::vector<mu2e::TrkStrawHitCalibInfo>* trkhitcalibs = nullptr;
+    mu2e::TrkCaloHitInfo* trkcalohit = nullptr;
+    std::vector<mu2e::SimInfo>* trkmcsim = nullptr;
+    mu2e::MVAResultInfo* trkqual = nullptr;
+    mu2e::MVAResultInfo* trkqual_alt = nullptr; // TODO: is there a way to allow for more than two...
+    mu2e::MVAResultInfo* trkpid = nullptr;
+  };
+  
+  typedef std::function<bool(Track&)> TrackCut;
+  typedef std::vector<Track> Tracks;
+} // namespace rooutil
 #endif

--- a/rooutil/inc/TrackHit.hh
+++ b/rooutil/inc/TrackHit.hh
@@ -6,16 +6,17 @@
 #include "EventNtuple/inc/TrkStrawHitInfoMC.hh"
 #include "EventNtuple/inc/TrkStrawHitCalibInfo.hh"
 
-struct TrackHit {
-  TrackHit() { }
+namespace rooutil {
+  struct TrackHit {
+    TrackHit() { }
 
-  // Pointers to the data
-  mu2e::TrkStrawHitInfo* reco = nullptr;
-  mu2e::TrkStrawHitInfoMC* mc = nullptr;
-  mu2e::TrkStrawHitCalibInfo* calib = nullptr;
-};
+    // Pointers to the data
+    mu2e::TrkStrawHitInfo* reco = nullptr;
+    mu2e::TrkStrawHitInfoMC* mc = nullptr;
+    mu2e::TrkStrawHitCalibInfo* calib = nullptr;
+  };
 
-typedef std::function<bool(TrackHit&)> TrackHitCut;
-typedef std::vector<TrackHit> TrackHits;
-
+  typedef std::function<bool(TrackHit&)> TrackHitCut;
+  typedef std::vector<TrackHit> TrackHits;
+} // namespace rooutil
 #endif

--- a/rooutil/inc/TrackSegment.hh
+++ b/rooutil/inc/TrackSegment.hh
@@ -8,23 +8,24 @@
 #include "EventNtuple/inc/CentralHelixInfo.hh"
 #include "EventNtuple/inc/KinematicLineInfo.hh"
 
-struct TrackSegment {
-  TrackSegment() { }
-  TrackSegment(mu2e::TrkSegInfo* trkseg) : trkseg(trkseg) { }
+namespace rooutil {
+  struct TrackSegment {
+    TrackSegment() { }
+    TrackSegment(mu2e::TrkSegInfo* trkseg) : trkseg(trkseg) { }
 
-  // Pointers to the data
-  mu2e::TrkSegInfo* trkseg = nullptr;
-  mu2e::SurfaceStepInfo* trksegmc = nullptr;
-  mu2e::LoopHelixInfo* trksegpars_lh = nullptr;
-  mu2e::CentralHelixInfo* trksegpars_ch = nullptr;
-  mu2e::KinematicLineInfo* trksegpars_kl = nullptr;
+    // Pointers to the data
+    mu2e::TrkSegInfo* trkseg = nullptr;
+    mu2e::SurfaceStepInfo* trksegmc = nullptr;
+    mu2e::LoopHelixInfo* trksegpars_lh = nullptr;
+    mu2e::CentralHelixInfo* trksegpars_ch = nullptr;
+    mu2e::KinematicLineInfo* trksegpars_kl = nullptr;
 
-  static bool earliest(const TrackSegment& seg1, const TrackSegment& seg2) {
-    return seg1.trkseg->time < seg2.trkseg->time;
-  }
-};
+    static bool earliest(const TrackSegment& seg1, const TrackSegment& seg2) {
+      return seg1.trkseg->time < seg2.trkseg->time;
+    }
+  };
 
-typedef std::function<bool(TrackSegment&)> TrackSegmentCut;
-typedef std::vector<TrackSegment> TrackSegments;
-
+  typedef std::function<bool(TrackSegment&)> TrackSegmentCut;
+  typedef std::vector<TrackSegment> TrackSegments;
+} // namespace rooutil
 #endif

--- a/rooutil/inc/common_cuts.hh
+++ b/rooutil/inc/common_cuts.hh
@@ -15,6 +15,7 @@
 #include "EventNtuple/rooutil/inc/TrackSegment.hh"
 #include "EventNtuple/rooutil/inc/CrvCoinc.hh"
 
+using namespace rooutil;
 //+ Track Segment Cuts - Directions
 bool is_downstream(TrackSegment& segment) { // track fit segment is going in +z direction
   // the sign of p_z tells us whether this segment is going upstream or downstream
@@ -196,7 +197,7 @@ bool three_of_four_coinc(CrvCoinc& crv_coinc) { // CRV coincidence has exactly t
 }
 
 //+ Combined Track & CrvCoinc Cuts
-bool track_crv_coincidence(TrackSegment& segment, CrvCoinc& crv_coinc) { 
+bool track_crv_coincidence(TrackSegment& segment, CrvCoinc& crv_coinc) {
   if ( abs(segment.trkseg->time - crv_coinc.reco->time) < 150 ) { return true; }
   else { return false; }
 }

--- a/rooutil/inc/cutflow.hh
+++ b/rooutil/inc/cutflow.hh
@@ -13,7 +13,7 @@ usage:
     };
 
     printCutflowTable(data);
-    
+
 */
 
 #ifndef cutflow_hh_
@@ -22,92 +22,93 @@ usage:
 #include "TH1.h"
 
 #include <format>
-// Structure to hold cutflow data
-struct CutflowEntry {
-    /*
-    Flexible struct. Two field "cut_name" e.g t>600 ns and "passed_count" e.g. 1000 events
-    */
-    std::string cut_name;
-    long long passed_count;
-};
+namespace rooutil {
+  // Structure to hold cutflow data
+  struct CutflowEntry {
+      /*
+      Flexible struct. Two field "cut_name" e.g t>600 ns and "passed_count" e.g. 1000 events
+      */
+      std::string cut_name;
+      long long passed_count;
+  };
 
-void printCutflowTable(const std::vector<CutflowEntry>& entries) {
-    /*
-    Formulate cut flow into terminal table
-    */
-    if (entries.empty()) {
-        std::cout << "No cutflow data to display." << std::endl;
-        return;
-    }
-    
-    // Define column widths
-    const int cut_name_width = 30;
-    const int passed_width = 15;
-    const int prev_change_width = 15;
-    const int initial_change_width = 15;
+  void printCutflowTable(const std::vector<CutflowEntry>& entries) {
+      /*
+      Formulate cut flow into terminal table
+      */
+      if (entries.empty()) {
+          std::cout << "No cutflow data to display." << std::endl;
+          return;
+      }
 
-    // Print the table header
-    std::cout << std::format("{:<{}} {:>{}} {:>{}} {:>{}}\n",
-                             "Cut", cut_name_width,
-                             "Passed", passed_width,
-                             "% Change (Prev)", prev_change_width,
-                             "% Change (Initial)", initial_change_width);
+      // Define column widths
+      const int cut_name_width = 30;
+      const int passed_width = 15;
+      const int prev_change_width = 15;
+      const int initial_change_width = 15;
 
-    // Print a separator line. std::format does not have the fill-character side effect.
-    std::cout << std::format("{:-<{}}\n", "", cut_name_width + passed_width + prev_change_width + initial_change_width + 3);
+      // Print the table header
+      std::cout << std::format("{:<{}} {:>{}} {:>{}} {:>{}}\n",
+                               "Cut", cut_name_width,
+                               "Passed", passed_width,
+                               "% Change (Prev)", prev_change_width,
+                               "% Change (Initial)", initial_change_width);
 
-    const long long initial_count = entries[0].passed_count;
-    long long last_count = 0;
+      // Print a separator line. std::format does not have the fill-character side effect.
+      std::cout << std::format("{:-<{}}\n", "", cut_name_width + passed_width + prev_change_width + initial_change_width + 3);
 
-    for (size_t i = 0; i < entries.size(); ++i) {
-        const auto& entry = entries[i];
-        
-        std::string percent_prev_str;
-        if (i > 0 && last_count > 0) {
-            double percent_change_prev = 100 - fabs(static_cast<double>(entry.passed_count - last_count) ) / last_count * 100.0;
-            percent_prev_str = std::format("{:+.2f}%", percent_change_prev);
-        } else {
-            percent_prev_str = "N/A";
-        }
-        
-        std::string percent_initial_str;
-        if (initial_count > 0) {
-            double percent_change_initial = 100 - fabs(static_cast<double>(entry.passed_count - initial_count)) / initial_count * 100.0;
-            percent_initial_str = std::format("{:+.2f}%", percent_change_initial);
-        } else {
-            percent_initial_str = "N/A";
-        }
+      const long long initial_count = entries[0].passed_count;
+      long long last_count = 0;
 
-        std::cout << std::format("{:<{}} {:>{}} {:>{}} {:>{}}\n", 
-                                 entry.cut_name, cut_name_width,
-                                 entry.passed_count, passed_width,
-                                 percent_prev_str, prev_change_width,
-                                 percent_initial_str, initial_change_width);
-        
-        last_count = entry.passed_count;
-    }
-}
+      for (size_t i = 0; i < entries.size(); ++i) {
+          const auto& entry = entries[i];
 
-TH1F* MakeCutflowHist(std::vector<CutflowEntry> data){
-    /*
-    Provides a 1D histogram with labelled xaxis
-    */
-    int n_entries = data.size();
-    std::vector<double> x_vals, y_vals;
+          std::string percent_prev_str;
+          if (i > 0 && last_count > 0) {
+              double percent_change_prev = 100 - fabs(static_cast<double>(entry.passed_count - last_count) ) / last_count * 100.0;
+              percent_prev_str = std::format("{:+.2f}%", percent_change_prev);
+          } else {
+              percent_prev_str = "N/A";
+          }
 
-    TH1F* h_cutflow = new TH1F("h_cutflow", "Event Cutflow;;Number of Events", n_entries, 0, n_entries);
-    h_cutflow->SetStats(0); 
-    
-    for (int i = 0; i < n_entries; ++i) {
-        h_cutflow->GetXaxis()->SetBinLabel(i + 1, data[i].cut_name.c_str());
-        h_cutflow->SetBinContent(i + 1, data[i].passed_count);
-    }
-    
-    h_cutflow->Draw("HIST B");
-    h_cutflow->SetFillColor(kBlue-7);
-    h_cutflow->SetLineColor(kBlack);
-    return h_cutflow;
+          std::string percent_initial_str;
+          if (initial_count > 0) {
+              double percent_change_initial = 100 - fabs(static_cast<double>(entry.passed_count - initial_count)) / initial_count * 100.0;
+              percent_initial_str = std::format("{:+.2f}%", percent_change_initial);
+          } else {
+              percent_initial_str = "N/A";
+          }
+
+          std::cout << std::format("{:<{}} {:>{}} {:>{}} {:>{}}\n",
+                                   entry.cut_name, cut_name_width,
+                                   entry.passed_count, passed_width,
+                                   percent_prev_str, prev_change_width,
+                                   percent_initial_str, initial_change_width);
+
+          last_count = entry.passed_count;
+      }
   }
 
+  TH1F* MakeCutflowHist(std::vector<CutflowEntry> data){
+      /*
+      Provides a 1D histogram with labelled xaxis
+      */
+      int n_entries = data.size();
+      std::vector<double> x_vals, y_vals;
+
+      TH1F* h_cutflow = new TH1F("h_cutflow", "Event Cutflow;;Number of Events", n_entries, 0, n_entries);
+      h_cutflow->SetStats(0);
+
+      for (int i = 0; i < n_entries; ++i) {
+          h_cutflow->GetXaxis()->SetBinLabel(i + 1, data[i].cut_name.c_str());
+          h_cutflow->SetBinContent(i + 1, data[i].passed_count);
+      }
+
+      h_cutflow->Draw("HIST B");
+      h_cutflow->SetFillColor(kBlue-7);
+      h_cutflow->SetLineColor(kBlack);
+      return h_cutflow;
+    }
+} // namespace rooutil
 #endif
 


### PR DESCRIPTION
This adds a namespace to the rooutil objects to not collide with any analysis framework code (e.g. `Track` --> `rooutil::Track`). This creates many diffs due to adding an extra indentation in header files...

I also did a couple of small edits that move some checks into separate functions to reduce some repetition.