### PR TITLE
move files out of ConditionsService

### DIFF
--- a/fcl/prolog_mc_reweighters.fcl
+++ b/fcl/prolog_mc_reweighters.fcl
@@ -24,7 +24,7 @@ dioLLWeight : {
   genParticleTag : "compressDigiMCs"
   genParticlePdgId : 11
   genParticleGenId : dioTail
-  spectrumFileName : "Offline/ConditionsService/data/czarnecki_szafron_Al_2016.tbl"
+  spectrumFileName : "Offline/EventGenerator/data/czarnecki_szafron_Al_2016.tbl"
   BinCenter : false
 }
 END_PROLOG


### PR DESCRIPTION
As part of decommissioning ConditionsService, we've moved the config files to EventGenerator.  This PR tracks that move, which is now on the head of Offline