### PR TITLE
Fix fcl configuration for CRV VST data

### DIFF
--- a/fcl/from_rec-crv-vst.fcl
+++ b/fcl/from_rec-crv-vst.fcl
@@ -1,9 +1,7 @@
 #include "EventNtuple/fcl/from_mcs-mockdata_noMC.fcl"
 
-source.inputCommands : [ "drop mu2e::DAQerrors_*_*_*" ]
-
 physics.analyzers.EventNtuple.FillCRVDigis : true
-physics.analyzers.EventNtuple.FillCRVPulses : true
+physics.analyzers.EventNtuple.FillCRVPulses : false # true
 physics.analyzers.EventNtuple.branches : [ ] # no track branches
 physics.analyzers.EventNtuple.FillCaloClusters : false # no calorimeter
 physics.analyzers.EventNtuple.FillCaloHits : false # no calorimeter


### PR DESCRIPTION
@ehrlich-uva reported that the EventNtuple was not filling for new CRV data. This ended up being fixed by removing the fcl parameter that was dropping an old data product that was in earlier data files. 

However, this revealed an issue with the ```crvpulses``` branch, which requires an EventWindowMarker so that it can be filled. This data product is not in the current CRV files.

This PR fixes the initial problem but we have turned off the ```crvpulses``` branch for CRV VST data for the time being. I will open an issue for this.