### PR TITLE
CRV inference 

### DIFF
--- a/fcl/from_mcs-mockdata_crvInf.fcl
+++ b/fcl/from_mcs-mockdata_crvInf.fcl
@@ -1,0 +1,12 @@
+#include "ArtAnalysis/CrvInference/fcl/prolog.fcl"
+#include "EventNtuple/fcl/from_mcs-mockdata.fcl"
+
+services.GeometryService.inputFile : "Offline/Mu2eG4/geom/geom_common_MDC2020.txt"
+
+physics.producers.CrvInference : {
+  @table::CrvInference
+  KalSeedPtrCollection : "MergeKKAll"
+}
+
+physics.EventNtuplePath : [ @sequence::EventNtuple.Path, CrvInference ]
+physics.analyzers.EventNtuple.CrvInferenceTag : "CrvInference"

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -395,11 +395,11 @@ namespace mu2e {
     _fillcrvpulses(conf().fillcrvpulses()),
     _fillcrvdigis(conf().fillcrvdigis()),
     _crvPlaneY(conf().crvPlaneY()),
-    _fillCrvInference(conf().crvInferenceTag(_crvInferenceTag)),
     _infoMCStructHelper(conf().infoMCStructHelper()),
     _buffsize(conf().buffsize()),
     _splitlevel(conf().splitlevel())
   {
+    _fillCrvInference = conf().crvInferenceTag(_crvInferenceTag);
 
     // decode fit type
     for(size_t ifit=0;ifit < fitNames.size();++ifit){

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -170,6 +170,8 @@ namespace mu2e {
         fhicl::Atom<bool> fillcrvdigis{Name("FillCRVDigis"),Comment("Flag for turning on crvdigis branch"), false};
         // CRV -- other
         fhicl::Atom<double> crvPlaneY{Name("CrvPlaneY"),Comment("y of center of the top layer of the CRV-T counters"), 2751.485};  //This belongs in KinKalGeom as an intersection plane, together with the rest of the CRV planes FIXME
+        // CRV inference
+        fhicl::OptionalAtom<art::InputTag> crvInferenceTag{Name("CrvInferenceTag"), Comment("Tag for CrvInference associations (art::Assns<KalSeed, CrvCoincidenceCluster, MVAResult>)")};
         // MC truth
         fhicl::Atom<bool> fillmc{Name("FillMCInfo"),Comment("Global switch to turn on/off MC info"),true};
         fhicl::Table<InfoMCStructHelper::Config> infoMCStructHelper{Name("InfoMCStructHelper"), Comment("Configuration for the InfoMCStructHelper")};
@@ -324,6 +326,10 @@ namespace mu2e {
       // CRV -- fhicl parameters
       bool _fillcrvcoincs, _fillcrvpulses, _fillcrvdigis;
       double _crvPlaneY;  // needs to move to KinKalGeom FIXME
+      // CRV inference
+      bool _fillCrvInference;
+      art::InputTag _crvInferenceTag;
+      std::vector<std::vector<MVAResultInfo>> _crvInference;
       // CRV (output)
       std::vector<CrvHitInfoReco> _crvcoincs;
       std::map<BranchIndex, std::vector<CrvHitInfoReco>> _allBestCrvs; // there can be more than one of these per track type
@@ -389,6 +395,7 @@ namespace mu2e {
     _fillcrvpulses(conf().fillcrvpulses()),
     _fillcrvdigis(conf().fillcrvdigis()),
     _crvPlaneY(conf().crvPlaneY()),
+    _fillCrvInference(conf().crvInferenceTag(_crvInferenceTag)),
     _infoMCStructHelper(conf().infoMCStructHelper()),
     _buffsize(conf().buffsize()),
     _splitlevel(conf().splitlevel())
@@ -610,6 +617,10 @@ namespace mu2e {
           _ntuple->Branch("crvpulsesmc.",&_crvpulsesmc,_buffsize,_splitlevel);
         }
       }
+    }
+    // CRV cosmic inference
+    if(_fillCrvInference) {
+      _ntuple->Branch("crvcosmic.",&_crvInference,_buffsize,_splitlevel);
     }
     // helix info
     if(_conf.helices()) _ntuple->Branch("helices.",&_hinfos,_buffsize,_splitlevel);
@@ -986,6 +997,29 @@ namespace mu2e {
                                               _crvdigis);
       }
 
+    }
+
+    // fill CRV cosmic inference scores
+    if(_fillCrvInference) {
+      _crvInference.clear();
+      art::Handle<art::Assns<KalSeed, CrvCoincidenceCluster, MVAResult>> crvInfHandle;
+      event.getByLabel(_crvInferenceTag, crvInfHandle);
+      if(crvInfHandle.isValid()) {
+        // group scores by track
+        // downstream electron track has scores indexed by coincidence cluster
+        art::Ptr<KalSeed> thisKalSeed;
+        for(const auto& assn : *crvInfHandle) {
+          if(assn.first != thisKalSeed) {
+            _crvInference.emplace_back(); // new track
+            thisKalSeed = assn.first;
+          }
+          // Run the inference and get the result
+          MVAResultInfo info;
+          info.result = assn.data->_value;
+          info.valid = true; // valid if there is a score
+          _crvInference.back().push_back(info);
+        }
+      }
     }
 
     // fill MC information unrelated to any reconstructed object

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -999,25 +999,35 @@ namespace mu2e {
 
     }
 
-    // fill CRV cosmic inference scores
+    // fill CRV cosmic inference scores (T x C structure aligned with trk branches)
     if(_fillCrvInference) {
       _crvInference.clear();
+      // Init associations from CrvInference module: KalSeed <-> CrvCoincidenceCluster with MVAResult data product
       art::Handle<art::Assns<KalSeed, CrvCoincidenceCluster, MVAResult>> crvInfHandle;
+      // grab the associations from the art::Event  
       event.getByLabel(_crvInferenceTag, crvInfHandle);
-      if(crvInfHandle.isValid()) {
-        // group scores by track
-        // downstream electron track has scores indexed by coincidence cluster
-        art::Ptr<KalSeed> thisKalSeed;
+      // build a map from KalSeed ptr to scores
+      std::map<art::Ptr<KalSeed>, std::vector<MVAResultInfo>> crvInfMap;
+      // Get the scores from the associations and fill the map
+      if(crvInfHandle.isValid()) { 
+        // loop through association
         for(const auto& assn : *crvInfHandle) {
-          if(assn.first != thisKalSeed) {
-            _crvInference.emplace_back(); // new track
-            thisKalSeed = assn.first;
-          }
-          // Run the inference and get the result
           MVAResultInfo info;
-          info.result = assn.data->_value;
-          info.valid = true; // valid if there is a score
-          _crvInference.back().push_back(info);
+          info.result = assn.data->_value; // the model score
+          info.valid = true; // true if assns is valid
+          crvInfMap[assn.first].push_back(info); 
+        }
+      }
+      // fill the branch
+      // iterate over all tracks to keep alignment with trk branches
+      // this means filling empty vectors for tracks with no coincidence 
+      const auto& kseedptr_coll = *_allKSPCHs.at(0);
+      for(size_t i = 0; i < kseedptr_coll.size(); ++i) {
+        auto it = crvInfMap.find(kseedptr_coll[i]);
+        if(it != crvInfMap.end()) {
+          _crvInference.push_back(it->second); // fill
+        } else {
+          _crvInference.emplace_back(); // empty vector for tracks with no CRV match
         }
       }
     }


### PR DESCRIPTION
## Summary

- Add optional `crvcosmic.` branch to EventNtuple, storing CRV cosmic veto BDT scores
- Structure is TxC (track x cluster), with each array aligned with the elements of `trk.` branch
    -  Each track has a vector of `MVAResultInfo` scores, one per CRV coincidence cluster
    - Tracks with no CRV match get an empty vector, preserving alignment
- Controlled by `CrvInferenceTag` fcl parameter 
    - No branch is created when absent (backwards compatible)
- Added `from_mcs-mockdata_crvInf.fcl` for ntupling with CrvInference enabled

## Example output 

One event with 4 track hypotheses and 2 CRV clusters:

[pyprint] [INFO] -------------------------------------------------------------------------------------
[pyprint] [INFO] trk.trk.pdg: [11, -11, 13, -13]
[pyprint] [INFO] trkfit.trksegs.mom.fCoordinates.fX: [[11.9, -88.8, 63.3, -140, 13.6], [...], ..., [-11.8, 89.3, -61.7, 136, -14.6]]
[pyprint] [INFO] trkfit.trksegs.mom.fCoordinates.fY: [[118, -80.1, -99.5, 90.2, 128], [-118, ...], ..., [-118, 78, 101, -94, -127]]
[pyprint] [INFO] trkfit.trksegs.mom.fCoordinates.fZ: [[129, 129, 129, 56.4, 119], [-129, ...], ..., [-129, -128, -130, -56.9, -119]]
[pyprint] [INFO] trkfit.trksegs.pos.fCoordinates.fX: [[677, 24.8, -40.7, 385, 661], [677, ..., 661], ..., [677, 34.9, -45, 394, 661]]
[pyprint] [INFO] trkfit.trksegs.pos.fCoordinates.fY: [[-87.4, 234, -268, 214, -87.5], [...], ..., [-87.4, 233, -262, 204, -93.8]]
[pyprint] [INFO] trkfit.trksegs.pos.fCoordinates.fZ: [[10.1, -1.63e+03, 1.64e+03, -5.97e+03, -2.59e+03], ..., [10.1, ..., -2.58e+03]]
[pyprint] [INFO] trkfit.trksegs.time: [[1.24e+03, 1.23e+03, 1.25e+03, 1.21e+03, 1.23e+03], ..., [1.24e+03, ...]]
[pyprint] [INFO] trkfit.trksegs.dmom: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]
[pyprint] [INFO] trkfit.trksegs.momerr: [[0.464, 0.467, 0.459, 0.467, 0.467], ..., [0.537, 0.541, ..., 0.541, 0.541]]
[pyprint] [INFO] trkfit.trksegs.inbounds: [[True, True, True, True, True], [...], ..., [True, True, True, True, True]]
[pyprint] [INFO] trkfit.trksegs.gap: [[False, False, False, False, False], ..., [False, False, ..., False, False]]
[pyprint] [INFO] trkfit.trksegs.sid: [[1, 0, 2, 96, 95], [1, 0, 2, 96, 95], [1, 0, ..., 95], [1, 0, 2, 96, 95]]
[pyprint] [INFO] trkfit.trksegs.sindex: [[0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0], [0, 0, 0, 0, 0]]
[pyprint] [INFO] crv.crvcoincs.PEs: [1.74e+03, 1.11e+03]
[pyprint] [INFO] mva.crvcosmic.valid: [[True, True], [True, True], [True, True], [True, True]]
[pyprint] [INFO] mva.crvcosmic.result: [[0.999, 0.97], [0.999, 0.97], [0.999, 0.97], [0.999, 0.97]]
[pyprint] [INFO] -------------------------------------------------------------------------------------

```
trk.pdg: [11, -11, 13, -13]
crvcoincs.PEs: [1.74e+03, 1.11e+03]
crvcosmic.valid: [[True, True], [True, True], [True, True], [True, True]]
crvcosmic.result: [[0.999, 0.97], [0.999, 0.97], [0.999, 0.97], [0.999, 0.97]]
```

- High score (~1.0): the coincidence is cosmic-like and the track is nearby in time/space
- Low score (~0.0): the coincidence is pileup/noise-like and/or the track is far from the coincidence

Plots from test `EventNtuple` files, showing separation of classes. 

<img width="453.25" height="333.5" alt="h1o_selection" src="https://github.com/user-attachments/assets/14e9b0b2-cddc-466c-8448-31350c15b3bf" />


## Details

The `CrvInference` producer module (in `ArtAnalysis/CrvInference`) pairs every `KalSeed` with every `CrvCoincidenceCluster` and computes an XGBoost BDT score indicating the probability that the coincidence is from a genuine cosmic. EventNtupleMaker reads the resulting `art::Assns<KalSeed, CrvCoincidenceCluster, MVAResult>` and stores the scores in a `crvcosmic.` branch with fields `result` (the BDT score) and `valid`.

The branch uses `fhicl::OptionalAtom` so existing fcl configurations are unaffected. To enable, add the input tag `physics.analyzers.EventNtuple.CrvInferenceTag : "CrvInference"`.

