### PR TITLE
Update location of data files

### DIFF
--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -10,7 +10,7 @@ BEGIN_PROLOG
 # Track quality module
 TrkQual : {
   module_type : TrackQuality
-  datFilename : "Offline/TrkDiag/data/TrkQual_ANN1_v2.dat"
+  datFilename : "ArtAnalysis/TrkDiag/data/TrkQual_ANN1_v2.dat"
 }
 TrkQualDeM           : @local::TrkQual
 TrkQualDeM.KalSeedPtrCollection : "MergeKKDeM"
@@ -54,7 +54,7 @@ TrkPID : {
   module_type : TrackPID
   MaxDE : 500.0 # MeV
   DeltaTOffset : -1.15 # specific to MDC2018h
-  datFilename : "Offline/TrkDiag/data/TrackPID_v1.dat"
+  datFilename : "ArtAnalysis/TrkDiag/data/TrackPID_v1.dat"
 }
 # this module only makes sense for downstream electron fits
 TrkPIDDeM          : @local::TrkPID
@@ -303,7 +303,7 @@ EventNtupleMaker : {
   FillHitCalibInfo : false
   FillTriggerInfo : true
   TriggerProcessName : "Digitize"
-  TriggerPathSuffix : "DigitizePath"  
+  TriggerPathSuffix : "DigitizePath"
   FillCRVCoincs : true
   FillCRVPulses : false
   FillCRVDigis : false


### PR DESCRIPTION
This is related to issue 359, that EventNtuple depends on TrkDiag. As TrkDiag was mirgated to ArtAnalysis the immediate fix is to update the file path, but a longer term solution is still needed.