### PR TITLE
New calorimeter brancher

### DIFF
--- a/doc/branches.md
+++ b/doc/branches.md
@@ -138,9 +138,21 @@ The branch is empty if there are no CRV hit during the event.
 | crvcoincsmcplane |  Vector branch |   information about the point where the MC trajectory crosses the xz plane of CRV-T| [see CrvPlaneInfoMC.hh](../inc/CrvPlaneInfoMC.hh)
 ## Trigger Branches
 
-Each element in these branch corresponds to a different Kalman fit hypotheses to reconstruct the track:
+Trigger branches store trigger decision information for each event and track hypothesis. Each trigger branch corresponds to a different trigger path or decision criterion.
 
-Trigger branches are prefixed with ```trig_```. To find the names of the trigger branches run ```checkEventNtuple filename.root```
+Trigger branches are named with the prefix `trig_` followed by the trigger name. The structure of trigger branches is a single object per event containing an array of boolean decision bits, one for each trigger name.
+
+**TrigInfo Structure:**
+- **`_triggerArray[ntrig_]`**: A boolean array with up to 500 trigger decision bits, where `ntrig_ = 500`
+- Each element is a boolean that indicates whether the trigger passed (true) or failed (false) for that event
+- The index corresponds to a specific trigger path or decision algorithm
+
+To discover the names and meanings of all trigger branches available in your file, run:
+```
+checkEventNtuple filename.root
+```
+
+This will display the mapping of indices to trigger names, allowing you to correctly interpret the trigger array. For more details about the trigger structure, see [TrigInfo.hh](../inc/TrigInfo.hh).
 ## Deprecated Branches
 
 These branches are remnants from trkana and are deprecated.

--- a/doc/branches.md
+++ b/doc/branches.md
@@ -96,7 +96,7 @@ Each branch can be read independently, but elements contain indexes to other bra
 - Each recodi contains index of its raw digi (`caloDigiIdx_`) and parent hit index (`caloHitIdx_`)
 - Each raw digi contains index of parent recodi if any (`caloRecoDigiIdx_`)
 
-**Hierarchy:** clusters ← hits ← recodigis ← digis
+**Hierarchy:** digis --> recodigis --> hits --> clusters
 
 Example: cluster 3 has `hits_ = {12, 13, 14, 15}`. Each of those hits will have `clusterIdx_ = 3`.
 Calorimeter hits store crystal position in (x,y,z) with frame origin at tracker center.
@@ -117,7 +117,8 @@ The vector is aligned with `caloclusters` (same size & indices), with each eleme
 
 **Particle Information:**
 The `calomcsim` branch contains all unique SimParticles that contributed to calorimeter clusters across the entire event.
-Each MC particle is indexed via the `simParticleIds` field in the MC cluster/hit.
+This branch can be populated from either the `caloclusters` branch or by tracing MC truth back through the `calodigis` branch (both paths contain the necessary SimParticle information).
+Each MC particle is indexed via the `simParticleIds` field in the MC cluster/hit or digi.
 
 | branch | structure | explanation | key fields | leaf information |
 |--------|-----------|-------------|-----------|------------------|

--- a/doc/branches.md
+++ b/doc/branches.md
@@ -109,20 +109,24 @@ Calorimeter hits store crystal position in (x,y,z) with frame origin at tracker 
 | calodigis |  Vector branch |   raw calorimeter digis with waveform data and parent recodi index| `SiPMID_`, `diskID_`, `t0_` (first sample time), `waveform_`, `peakpos_` (peak index), `posX_`, `posY_`, `caloRecoDigiIdx_` | [see CaloDigiInfo.hh](../inc/CaloDigiInfo.hh)
 ## Calorimeter MC Branches
 
-The calorimeter MC branches provide MC-truth information aligned with reconstructed clusters and hits.
+The calorimeter MC branches provide MC-truth information at different levels of the calorimeter reconstruction hierarchy.
 
-**Cluster MC Information:**
-The `caloclustersmc` branch is a vector of MC clusters associated with reconstructed clusters.
-The vector is aligned with `caloclusters` (same size & indices), with each element corresponding to true particles depositing energy.
+**Alignment with Reconstruction Branches:**
+MC information branches are aligned with their corresponding reco branches:
+- `caloclustersmc` ← aligned with `caloclusters` (same size & indices)
+- `calohitsmc` ← aligned with `calohits` (same size & indices)
+- `calodigismc` ← aligned with `calodigis` (same size & indices; raw digi MC truth) (also: `calorecodigis` too)
+- `calodigisim` ← unique SimParticles from raw digis
+- `calomcsim` ← unique SimParticles from MC clusters
 
-**Particle Information:**
-The `calomcsim` branch contains all unique SimParticles that contributed to calorimeter clusters across the entire event.
-This branch can be populated from either the `caloclusters` branch or by tracing MC truth back through the `calodigis` branch (both paths contain the necessary SimParticle information).
-Each MC particle is indexed via the `simParticleIds` field in the MC cluster/hit or digi.
+Each MC element contains `simParticleIds` to index into the corresponding `*mcsim` branch for genealogy information.
 
 | branch | structure | explanation | key fields | leaf information |
 |--------|-----------|-------------|-----------|------------------|
 | caloclustersmc |  Vector branch |   MC-truth information for calorimeter clusters (aligned with caloclusters)| `nsim` (# of sim particles), `etot` (total true energy), `tavg` (avg time), `eprimary` (primary particle energy), `tprimary` (primary time), `simParticleIds`, `simRels` (MCRelationship), `hits_`, `prel` (primary to event primary relationship) | [see CaloClusterInfoMC.hh](../inc/CaloClusterInfoMC.hh)
+| calohitsmc |  Vector branch |   MC-truth information for calorimeter hits (aligned with calohits)| `nsim`, `eDep`, `eDepG4`, `eprimary`, `tprimary`, `eDeps`, `tDeps`, `momentumIns`, `simParticleIds`, `simRels`, `caloClusterIdx_`, etc. | [see CaloHitInfoMC.hh](../inc/CaloHitInfoMC.hh)
+| calodigismc |  Vector branch |   MC-truth information for raw calorimeter digis (aligned with calodigis)| `nsim`, `eDep`, `eDepG4`, `eprimary`, `tprimary`, `eDeps`, `tDeps`, `momentumIns`, `simParticleIds`, `simRels`, `caloHitIdx_`, `crystalID_`, `diskID_`, `energyCorr_`, `timeCorr_`, `posX_`, `posY_` | [see CaloDigiMCInfo.hh](../inc/CaloDigiMCInfo.hh)
+| calodigisim |  Vector branch |   unique SimParticles in all raw digis (genealogy information)| SimParticle genealogy info | [see SimInfo.hh](../inc/SimInfo.hh)
 | calomcsim |  Vector branch |   unique SimParticles in all MC clusters (genealogy information)| SimParticle genealogy info | [see SimInfo.hh](../inc/SimInfo.hh)
 ## CRV Branches
 

--- a/doc/branches.md
+++ b/doc/branches.md
@@ -89,7 +89,6 @@ The branch is empty if there are no time clusters during the event.
 ## Calorimeter Branches
 
 These branches are vectors of calorimeter clusters/hits/recodigis/digis that occurred during the event.
-The branch is empty if there are no calorimeter clusters during the event.
 
 Each branch can be read independently, but elements contain indexes to other branches to maintain parentage links:
 - Each cluster contains a vector `hits_` with indices of hits in this cluster

--- a/doc/branches.md
+++ b/doc/branches.md
@@ -32,10 +32,10 @@ If a Kalman fit fails or there are multiple downstream tracks to fit, the number
 |--------|-----------|-------------|------------------|
 | trk |  Vector branch |   information about the reconstructed track| [see TrkInfo.hh](../inc/TrkInfo.hh)
 | trkmc |  Vector branch |   MC-truth information about the track| [see TrkInfoMC.hh](../inc/TrkInfoMC.hh)
-| trkcalohit |  Vector branch |   the calorimeter cluster assigned to a track| [see TrkCaloHitInfo.hh](../inc/TrkCaloHitInfo.hh)
-| trkcalohitmc |  Vector branch |   MC-truth infromation for calorimeter clusters| [see CaloClusterInfoMC.hh](../inc/CaloClusterInfoMC.hh)
-| trkqual |  Vector branch |   the output of a multi-variate analysis (MVA)| [see MVAResultInfo.hh](../inc/MVAResultInfo.hh)
-| trkpid |  Vector branch |   the output of a multi-variate analysis (MVA)| [see MVAResultInfo.hh](../inc/MVAResultInfo.hh)
+| trkcalohit |  Vector branch |   calorimeter cluster associated with track with POCA and track-calo matching info (`active`, `did`, `poca`, `mom`, `cdepth`, `trkdepth`, `doca`, `dt`, `tresid`, `ctime`, `ctimeerr`, `edep`, `edeperr`)| [see TrkCaloHitInfo.hh](../inc/TrkCaloHitInfo.hh)
+| trkcalohitmc |  Vector branch |   MC-truth information for calorimeter clusters matched to track| [see CaloClusterInfoMC.hh](../inc/CaloClusterInfoMC.hh)
+| trkqual |  Vector branch |   quality output from multi-variate analysis (MVA)| [see MVAResultInfo.hh](../inc/MVAResultInfo.hh)
+| trkpid |  Vector branch |   particle ID output from multi-variate analysis (MVA)| [see MVAResultInfo.hh](../inc/MVAResultInfo.hh)
 ## Track segments Branches
 
 These branches contain 4 elements per event corresponding to different Kalman fit hypotheses (see Track branches).
@@ -88,32 +88,42 @@ The branch is empty if there are no time clusters during the event.
 | timeclusters |  Vector branch |   Information in a reconstructed time cluster| [see TimeClusterInfo.hh](../inc/TimeClusterInfo.hh)
 ## Calorimeter Branches
 
-These branches are vectors of calorimeter clusters/hits/recodigis/digis that happened during the event.
-The branch is empty if there are no calo cluster during the event.
+These branches are vectors of calorimeter clusters/hits/recodigis/digis that occurred during the event.
+The branch is empty if there are no calorimeter clusters during the event.
 
-While each branch can be read independently, i.e. all the hits of the event, each element contains indexes to the other branches for parentage link.
-The cluster element contains the vector 'hits_' containing the indexes of the hits branch belonging to this cluster.
-Similarly, each hit contains the indexes of its two recodigis (left and right channels) and the index of its parent cluster.
-Example: cluster 3 has hits_ = {12, 13, 14, 15}. Each of those hits will have 'clusterIdx_' = 3.
-Calo hits have the crystal (x,y,z) position saved. Frame origin is center of tracker.
-| branch | structure | explanation | leaf information |
-|--------|-----------|-------------|------------------|
-| caloclusters |  Vector branch |   calorimeter clusters with indices of hits| [see CaloClusterInfo.hh](../inc/CaloClusterInfo.hh)
-| calohits |  Vector branch |   calorimeter hits with indices of recodigis and of parent cluster| [see CaloHitInfo.hh](../inc/CaloHitInfo.hh)
-| calorecodigis |  Vector branch |   calorimeter recodigis with index of raw digi and of parent hit| [see CaloRecoDigiInfo.hh](../inc/CaloRecoDigiInfo.hh)
-| calodigis |  Vector branch |   calorimeter raw digis with index of parent recodigi if any| [see CaloDigiInfo.hh](../inc/CaloDigiInfo.hh)
+Each branch can be read independently, but elements contain indexes to other branches to maintain parentage links:
+- Each cluster contains a vector `hits_` with indices of hits in this cluster
+- Each hit contains indices of its recodigis (vector `recoDigis_`) and parent cluster index (`clusterIdx_`)
+- Each recodi contains index of its raw digi (`caloDigiIdx_`) and parent hit index (`caloHitIdx_`)
+- Each raw digi contains index of parent recodi if any (`caloRecoDigiIdx_`)
+
+**Hierarchy:** clusters ← hits ← recodigis ← digis
+
+Example: cluster 3 has `hits_ = {12, 13, 14, 15}`. Each of those hits will have `clusterIdx_ = 3`.
+Calorimeter hits store crystal position in (x,y,z) with frame origin at tracker center.
+
+| branch | structure | explanation | key fields | leaf information |
+|--------|-----------|-------------|-----------|------------------|
+| caloclusters |  Vector branch |   calorimeter clusters with indices of hits| `diskID_`, `time_`, `timeErr_`, `energyDep_`, `energyDepErr_`, `cog_` (centroid), `hits_` (vector of hit indices), `size_`, `isSplit_` | [see CaloClusterInfo.hh](../inc/CaloClusterInfo.hh)
+| calohits |  Vector branch |   calorimeter hits with crystal positions and indices to recodigis/cluster| `crystalId_`, `nSiPMs_`, `time_`, `timeErr_`, `eDep_`, `eDepErr_`, `crystalPos_`, `recoDigis_` (vector of recodi indices), `clusterIdx_` | [see CaloHitInfo.hh](../inc/CaloHitInfo.hh)
+| calorecodigis |  Vector branch |   fitted calorimeter recodigis with indices to raw digi and parent hit| `eDep_`, `eDepErr_`, `time_`, `timeErr_`, `chi2_`, `ndf_`, `pileUp_`, `caloDigiIdx_`, `caloHitIdx_` | [see CaloRecoDigiInfo.hh](../inc/CaloRecoDigiInfo.hh)
+| calodigis |  Vector branch |   raw calorimeter digis with waveform data and parent recodi index| `SiPMID_`, `diskID_`, `t0_` (first sample time), `waveform_`, `peakpos_` (peak index), `posX_`, `posY_`, `caloRecoDigiIdx_` | [see CaloDigiInfo.hh](../inc/CaloDigiInfo.hh)
 ## Calorimeter MC Branches
 
-The calorimeter mc clusters branch is a vector of MC clusters associated with the reconstructed clusters.
-The vector is aligned with the reconstructed clusters (same size & indexes).
+The calorimeter MC branches provide MC-truth information aligned with reconstructed clusters and hits.
 
-The calorimeter sim info branch is a vector of SimParticles belonging to any MC cluster.
-This branch is filled according to the MC clusters order, but no sim particles are repeated (if they belong to multiple clusters)
-The correct SimParticle can be retrieved from the MC cluster via the simid number
-| branch | structure | explanation | leaf information |
-|--------|-----------|-------------|------------------|
-| caloclustersmc |  Vector branch |   MC-truth infromation for calorimeter clusters| [see CaloClusterInfoMC.hh](../inc/CaloClusterInfoMC.hh)
-| calomcsim |  Vector branch |   information about SimParticles in genealogy| [see SimInfo.hh](../inc/SimInfo.hh)
+**Cluster MC Information:**
+The `caloclustersmc` branch is a vector of MC clusters associated with reconstructed clusters.
+The vector is aligned with `caloclusters` (same size & indices), with each element corresponding to true particles depositing energy.
+
+**Particle Information:**
+The `calomcsim` branch contains all unique SimParticles that contributed to calorimeter clusters across the entire event.
+Each MC particle is indexed via the `simParticleIds` field in the MC cluster/hit.
+
+| branch | structure | explanation | key fields | leaf information |
+|--------|-----------|-------------|-----------|------------------|
+| caloclustersmc |  Vector branch |   MC-truth information for calorimeter clusters (aligned with caloclusters)| `nsim` (# of sim particles), `etot` (total true energy), `tavg` (avg time), `eprimary` (primary particle energy), `tprimary` (primary time), `simParticleIds`, `simRels` (MCRelationship), `hits_`, `prel` (primary to event primary relationship) | [see CaloClusterInfoMC.hh](../inc/CaloClusterInfoMC.hh)
+| calomcsim |  Vector branch |   unique SimParticles in all MC clusters (genealogy information)| SimParticle genealogy info | [see SimInfo.hh](../inc/SimInfo.hh)
 ## CRV Branches
 
 These branches contain a vector where each element is a CRV hit that happened during the event.

--- a/fcl/from_dig-calo.fcl
+++ b/fcl/from_dig-calo.fcl
@@ -1,0 +1,57 @@
+#include "Offline/fcl/minimalMessageService.fcl"
+#include "Offline/fcl/standardProducers.fcl"
+#include "Offline/fcl/standardServices.fcl"
+#include "EventNtuple/fcl/prolog.fcl"
+
+process_name : EventNtuple
+
+source : { module_type : RootInput }
+
+services : {
+  @table::Services.Reco
+}
+
+physics : {
+  analyzers : {
+    @table::EventNtuple.analyzers
+  }
+
+  e1 : [ EventNtuple ]
+}
+
+physics.trigger_paths : [ ]
+physics.end_paths : [ e1 ]
+
+#Tags to fill PBI information
+#physics.analyzers.EventNtuple.PBTTag : "EWMProducer"
+#physics.analyzers.EventNtuple.PBTMCTag : "EWMProducer"
+physics.analyzers.EventNtuple.RecoCountTag : ""
+physics.analyzers.EventNtuple.PBTTag : ""
+physics.analyzers.EventNtuple.PBTMCTag : ""
+physics.analyzers.EventNtuple.SimParticlesTag : "CaloShowerStepMaker"
+#Turn off tracker and other branches
+physics.analyzers.EventNtuple.branches : [ ]
+physics.analyzers.EventNtuple.FillTrkQual : false
+physics.analyzers.EventNtuple.FillTriggerInfo : false
+physics.analyzers.EventNtuple.FillHitInfo : false
+physics.analyzers.EventNtuple.FillCRVCoincs : false
+
+#Toggle calo branches
+physics.analyzers.EventNtuple.FillCaloClusters : false
+physics.analyzers.EventNtuple.FillCaloHits : false
+physics.analyzers.EventNtuple.FillCaloRecoDigis : false
+physics.analyzers.EventNtuple.FillCaloDigis : true
+
+physics.analyzers.EventNtuple.CaloShowerSimTag : "CaloShowerROMaker"
+physics.analyzers.EventNtuple.CaloDigisTag : "CaloDigiMaker"
+
+#Toggle calo MC branches
+physics.analyzers.EventNtuple.FillMCInfo : false
+physics.analyzers.EventNtuple.FillCaloMC : true
+physics.analyzers.EventNtuple.FillCaloClustersMC : false
+physics.analyzers.EventNtuple.FillCaloHitsMC : false
+physics.analyzers.EventNtuple.FillCaloSimInfos : false
+physics.analyzers.EventNtuple.FillCaloDigiSimInfos : true
+physics.analyzers.EventNtuple.FillCaloDigisMC : true
+
+services.TFileService.fileName: "nts.owner.description.version.sequencer.root"

--- a/helper/ntuplehelper.py
+++ b/helper/ntuplehelper.py
@@ -3,7 +3,7 @@ import os
 class nthelper:
 
     single_object_branches = ['evtinfo', 'evtinfomc', 'hitcount', 'tcnt', 'crvsummary', 'crvsummarymc']
-    vector_object_branches = ['trk', 'trkmc', 'trkcalohit', 'trkcalohitmc', 'timeclusters', 'caloclustersmc', 'calomcsim', 'caloclusters', 'calohits', 'calorecodigis', 'calodigis', 'crvcoincs', 'crvcoincsmc', 'crvcoincsmcplane', 'trkqual', 'trkpid', 'mcsteps']
+    vector_object_branches = ['trk', 'trkmc', 'trkcalohit', 'trkcalohitmc', 'timeclusters', 'caloclustersmc', 'calohitsmc', 'calodigismc', 'calomcsim', 'calodigisim', 'caloclusters', 'calohits', 'calorecodigis', 'calodigis', 'crvcoincs', 'crvcoincsmc', 'crvcoincsmcplane', 'crvpulses', 'crvdigis', 'crvpulsesmc', 'trkqual', 'trkpid', 'mcsteps']
     vector_vector_object_branches = ['trksegs', 'trksegpars_lh', 'trksegpars_ch', 'trksegpars_kl', 'trkmcsim', 'trkhits', 'trkhitsmc', 'trkmats', 'trkhitcalibs', 'trkmcsci', 'trkmcssi', 'trksegsmc' ]
 
     evt_branches = ['evtinfo','evtinfomc','hitcount','tcnt']
@@ -14,8 +14,8 @@ class nthelper:
     general_mc_branches = [ 'mcsteps' ]
     basic_branches = [ 'timeclusters' ]
     calo_branches = ['caloclusters', 'calohits', 'calorecodigis', 'calodigis']
-    calo_mc_branches = ['caloclustersmc', 'calomcsim']
-    crv_branches = ['crvsummary','crvsummarymc','crvcoincs','crvcoincsmc','crvcoincsmcplane']
+    calo_mc_branches = ['caloclustersmc', 'calohitsmc', 'calodigismc', 'calomcsim', 'calodigisim']
+    crv_branches = ['crvsummary','crvsummarymc','crvcoincs','crvcoincsmc','crvcoincsmcplane','crvpulses','crvdigis','crvpulsesmc']
     deprecated_branches = ['trkmcsci','trkmcssi']
 
     track_types_dict = { 'kl' : "kinematic line fit (i.e. straight-line fit)",
@@ -51,7 +51,11 @@ class nthelper:
                            'trkmcssi' : "MCStepSummaryInfo",
                            'timeclusters' : "TimeClusterInfo",
                            'caloclustersmc': "CaloClusterInfoMC",
+                           'calohitmc' : "CaloHitInfoMC",
+                           'calohitsmc' : "CaloHitInfoMC",
+                           'calodigismc' : "CaloDigiMCInfo",
                            'calomcsim' : "SimInfo",
+                           'calodigisim' : "SimInfo",
                            'caloclusters' : "CaloClusterInfo",
                            'calohits' : "CaloHitInfo",
                            'calorecodigis' : "CaloRecoDigiInfo",
@@ -65,7 +69,10 @@ class nthelper:
                            "trkpid" : "MVAResultInfo",
                            "helices" : "HelixInfo",
                            "trksegsmc" : "SurfaceStepInfo",
-                           "mcsteps" : "MCStepInfo"
+                           "mcsteps" : "MCStepInfo",
+                           "crvpulses" : "CrvPulseInfoReco",
+                           "crvdigis" : "CrvWaveformInfo",
+                           "crvpulsesmc" : "CrvPulseInfoReco"
                           }
 
     #

--- a/inc/CaloDigiInfo.hh
+++ b/inc/CaloDigiInfo.hh
@@ -11,12 +11,15 @@ namespace mu2e
   struct CaloDigiInfo {
 
     int                 SiPMID_;           // Offline SiPM ID number
+    int                 diskID_;           // Offline disk ID number
     int                 t0_;               // Time of first waveform sample
     std::vector<int>    waveform_;         // Waveform
     int                 peakpos_;          // Waveform index of peak
     int                 caloRecoDigiIdx_;  // RecoDigi index
+    float               posX_;             // Crystal x position in detector frame
+    float               posY_;             // Crystal y position in detector frame
 
-    CaloDigiInfo() : SiPMID_(-1), t0_(0), waveform_(), peakpos_(0), caloRecoDigiIdx_(-1) {}
+    CaloDigiInfo() : SiPMID_(-1), t0_(0), waveform_(), peakpos_(0), caloRecoDigiIdx_(-1), posX_(0.0), posY_(0.0) {}
     void reset() { *this = CaloDigiInfo(); }
   };
 }

--- a/inc/CaloDigiMCInfo.hh
+++ b/inc/CaloDigiMCInfo.hh
@@ -1,0 +1,34 @@
+//
+// CaloDigiMCInfo: MC-truth information for calorimeter raw digis
+//
+#ifndef CaloDigiMCInfo_HH
+#define CaloDigiMCInfo_HH
+
+#include <vector>
+#include "Offline/MCDataProducts/inc/MCRelationship.hh"
+
+namespace mu2e
+{
+  struct CaloDigiMCInfo {
+
+    int nsim;                           // # of sim particles associated with this digi
+    float eDep;                         // total (corrected) deposited energy in the digi
+    float eDepG4;                       // total G4 deposited energy in the digi
+    float eprimary;                     // energy of the most energetic deposit
+    float tprimary;                     // time of the most energetic deposit
+    std::vector<float> eDeps;           // list of deposited energies
+    std::vector<float> tDeps;           // list of times of energy deposits
+    std::vector<float> momentumIns;     // list of the momentum of the SimParticle when entering in the disk
+    std::vector<int> simParticleIds;    // list of simparticle ids
+    std::vector<MCRelationship> simRels;// relationship to the particle that deposited the most energy in the calo digi
+    int caloHitIdx_;                    // CaloHit index
+    int crystalID_;                     // Crystal ID from CaloShowerSim
+    float energyCorr_;                  // corrected energy from CaloShowerSim
+    float timeCorr_;                    // corrected time from CaloShowerSim
+
+    CaloDigiMCInfo() : nsim(0), eDep(0.0), eDepG4(0.0), eprimary(0.0), tprimary(0.0), caloHitIdx_(-1), crystalID_(-1), energyCorr_(0.0), timeCorr_(0.0) {}
+
+    void reset() { *this = CaloDigiMCInfo(); }
+  };
+}
+#endif

--- a/inc/CaloDigiMCInfo.hh
+++ b/inc/CaloDigiMCInfo.hh
@@ -23,10 +23,13 @@ namespace mu2e
     std::vector<MCRelationship> simRels;// relationship to the particle that deposited the most energy in the calo digi
     int caloHitIdx_;                    // CaloHit index
     int crystalID_;                     // Crystal ID from CaloShowerSim
+    int diskID_;           // Offline disk ID number
     float energyCorr_;                  // corrected energy from CaloShowerSim
     float timeCorr_;                    // corrected time from CaloShowerSim
+    float posX_;                        // Crystal x position in detector frame
+    float posY_;                        // Crystal y position in detector frame
 
-    CaloDigiMCInfo() : nsim(0), eDep(0.0), eDepG4(0.0), eprimary(0.0), tprimary(0.0), caloHitIdx_(-1), crystalID_(-1), energyCorr_(0.0), timeCorr_(0.0) {}
+    CaloDigiMCInfo() : nsim(0), eDep(0.0), eDepG4(0.0), eprimary(0.0), tprimary(0.0), caloHitIdx_(-1), crystalID_(-1), energyCorr_(0.0), timeCorr_(0.0), posX_(0.0), posY_(0.0) {}
 
     void reset() { *this = CaloDigiMCInfo(); }
   };

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -9,13 +9,16 @@
 #include "Offline/MCDataProducts/inc/StrawDigiMC.hh"
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/MCDataProducts/inc/CrvCoincidenceClusterMC.hh"
+#include "EventNtuple/inc/CaloDigiMCInfo.hh"
 
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
+#include "Offline/MCDataProducts/inc/CaloShowerSim.hh"
 #include "EventNtuple/inc/TrkInfoMC.hh"
 #include "EventNtuple/inc/SimInfo.hh"
 #include "EventNtuple/inc/TrkStrawHitInfoMC.hh"
 #include "EventNtuple/inc/CaloClusterInfoMC.hh"
 #include "EventNtuple/inc/CaloHitInfoMC.hh"
+#include "EventNtuple/inc/CaloDigiMCInfo.hh"
 #include "EventNtuple/inc/MCStepInfo.hh"
 #include "EventNtuple/inc/MCStepSummaryInfo.hh"
 #include "EventNtuple/inc/SurfaceStepInfo.hh"
@@ -73,6 +76,8 @@ namespace mu2e {
       void fillHitInfoMCs(const KalSeed& kseed, const KalSeedMC& kseedmc, std::vector<std::vector<TrkStrawHitInfoMC>>& all_tshinfomcs);
       void fillCaloClusterInfoMC(CaloClusterMC const& ccmc, std::vector<CaloClusterInfoMC>& ccimc);
       void fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimc, int clusterIdx);
+      void fillCaloDigiMCInfo(CaloShowerSim const& shower, std::vector<CaloDigiMCInfo>& calodigimc);
+      void fillCaloDigiSimInfos(CaloShowerSim const& shower, std::vector<SimInfo>& cdsis);
       void fillCaloSimInfos(CaloClusterMC const& ccmc, std::vector<SimInfo>& csis);
       void fillExtraMCStepInfos(KalSeedMC const& kseedmc, StepPointMCCollection const& mcsteps,
                                 std::vector<MCStepInfos>& mcsics, std::vector<MCStepSummaryInfo>& mcssis);

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -81,6 +81,8 @@
 #include "EventNtuple/inc/MCStepInfo.hh"
 #include "EventNtuple/inc/SurfaceStepInfo.hh"
 #include "EventNtuple/inc/MCStepSummaryInfo.hh"
+#include "EventNtuple/inc/CaloDigiMCInfo.hh"
+#include "Offline/MCDataProducts/inc/CaloShowerSim.hh"
 
 // C++ includes.
 #include <iostream>
@@ -153,11 +155,13 @@ namespace mu2e {
         fhicl::Atom<art::InputTag> caloHitsTag{Name("CaloHitsTag"), Comment("Tag for Calorimeter hit collection"), art::InputTag()};
         fhicl::Atom<art::InputTag> caloRecoDigisTag{Name("CaloRecoDigisTag"), Comment("Tag for Calorimeter recodigi collection"), art::InputTag()};
         fhicl::Atom<art::InputTag> caloDigisTag{Name("CaloDigisTag"), Comment("Tag for Calorimeter digi collection"), art::InputTag()};
+        fhicl::Atom<art::InputTag> caloShowerSimTag{Name("CaloShowerSimTag"), Comment("Tag for Calorimeter shower sim collection"), art::InputTag()};
         // Calorimeter flags
         fhicl::Atom<bool> fillCaloClusters{Name("FillCaloClusters"),Comment("Flag for turning on Calo Clusters branch"), true};
         fhicl::Atom<bool> fillCaloHits{Name("FillCaloHits"),Comment("Flag for turning on Calo Hits branch"), false};
         fhicl::Atom<bool> fillCaloRecoDigis{Name("FillCaloRecoDigis"),Comment("Flag for turning on Calo RecoDigis branch"), false};
         fhicl::Atom<bool> fillCaloDigis{Name("FillCaloDigis"),Comment("Flag for turning on Calo Digis branch"), false};
+        fhicl::Atom<bool> fillCaloDigisMC{Name("FillCaloDigisMC"),Comment("Flag for turning on Calo Digis MC branch"), false};
         // CRV -- input tags
         fhicl::Atom<art::InputTag> crvCoincidencesTag{Name("CrvCoincidencesTag"), Comment("Tag for CrvCoincidenceCluster Collection"), art::InputTag()};
         fhicl::Atom<art::InputTag> crvRecoPulsesTag{Name("CrvRecoPulsesTag"), Comment("Tag for CrvRecopPulse Collection"), art::InputTag()};
@@ -188,6 +192,7 @@ namespace mu2e {
         fhicl::Atom<bool> fillCaloClustersMC{ Name("FillCaloClustersMC"),Comment("Fill Calo Cluster MC information"), true};
         fhicl::Atom<bool> fillCaloHitsMC{ Name("FillCaloHitsMC"),Comment("Fill Calo Hit MC information"), true};
         fhicl::Atom<bool> fillCaloSimInfos{ Name("FillCaloSimInfos"),Comment("Fill Sim particles information associated with calo clusters"), true};
+        fhicl::Atom<bool> fillCaloDigiSimInfos{ Name("FillCaloDigiSimInfos"),Comment("Fill Sim particles information associated with calo digis"), true};
         fhicl::Atom<art::InputTag> caloClusterMCTag{Name("CaloClusterMCTag"), Comment("Tag for CaloClusterMCCollection") ,art::InputTag()};
         // CRV MC
         fhicl::Atom<art::InputTag> crvCoincidenceMCsTag{Name("CrvCoincidenceMCsTag"), Comment("Tag for CrvCoincidenceClusterMC Collection"), art::InputTag()};
@@ -299,18 +304,21 @@ namespace mu2e {
       art::Handle<CaloHitCollection> _caloHits;
       art::Handle<CaloRecoDigiCollection> _caloRecoDigis;
       art::Handle<CaloDigiCollection> _caloDigis;
+      art::Handle<CaloShowerSimCollection> _caloShowerSim;
       std::vector<CaloClusterInfo> _caloCIs;
       std::vector<CaloHitInfo> _caloHIs;
       std::vector<CaloRecoDigiInfo> _caloRDIs;
       std::vector<CaloDigiInfo> _caloDIs;
+      std::vector<CaloDigiMCInfo> _caloDigiMCIs;
 
-      bool _fillcaloclusters, _fillcalohits, _fillcalorecodigis, _fillcalodigis;
+      bool _fillcaloclusters, _fillcalohits, _fillcalorecodigis, _fillcalodigis, _fillcalodigismc;
 
       // Calorimeter MC
       std::vector<CaloClusterInfoMC> _caloCIMCs; //Independent from tracker
       std::vector<CaloHitInfoMC> _caloHIMCs; //Independent from tracker
       std::vector<SimInfo> _caloSIMCs; //Sim particle infos associated with calo clusters
-      bool _fillcaloclustersmc, _fillcalohitsmc, _fillcalosiminfos;
+      std::vector<SimInfo> _caloDigiSIMCs; //Sim particle infos associated with calo digis
+      bool _fillcaloclustersmc, _fillcalohitsmc, _fillcalosiminfos, _fillcalodigisiminfos;
 
       // CRV (inputs)
       std::map<BranchIndex, std::vector<art::Handle<BestCrvAssns>>> _allBestCrvAssns;
@@ -380,10 +388,12 @@ namespace mu2e {
     _fillcalohits(conf().fillCaloHits()),
     _fillcalorecodigis(conf().fillCaloRecoDigis()),
     _fillcalodigis(conf().fillCaloDigis()),
+    _fillcalodigismc(conf().fillCaloDigisMC()),
     // Calorimeter MC
     _fillcaloclustersmc(conf().fillCaloClustersMC()),
     _fillcalohitsmc(conf().fillCaloHitsMC()),
     _fillcalosiminfos(conf().fillCaloSimInfos()),
+    _fillcalodigisiminfos(conf().fillCaloDigiSimInfos()),
     // CRV
     _fillcrvcoincs(conf().fillcrvcoincs()),
     _fillcrvpulses(conf().fillcrvpulses()),
@@ -393,7 +403,6 @@ namespace mu2e {
     _buffsize(conf().buffsize()),
     _splitlevel(conf().splitlevel())
   {
-
     // decode fit type
     for(size_t ifit=0;ifit < fitNames.size();++ifit){
       auto const& fname = fitNames[ifit];
@@ -402,12 +411,11 @@ namespace mu2e {
         break;
       }
     }
-
+    
     // Put all the branch configurations together
     for(const auto& branch_cfg : _conf.branches()){
       _allBranches.push_back(branch_cfg);
     }
-
     // Create all the info structs
     for (BranchIndex i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {
       auto i_branchConfig = _allBranches.at(i_branch);
@@ -430,7 +438,7 @@ namespace mu2e {
       if(_fillcalomc && _fillmc){
         _allMCTCHIs[i_branch] = std::vector<CaloClusterInfoMC>();
       }
-
+      std::cout << "[EventNtupleMaker Constructor] Finished creating track info structs for branch " << i_branchConfig.branch() << "." << std::endl;
       RecoQualInfo rqi;
       _allRQIs.push_back(rqi);
 
@@ -438,20 +446,20 @@ namespace mu2e {
       _allTSHCIs[i_branch] = std::vector<std::vector<TrkStrawHitCalibInfo>>();
       _allTSMIs[i_branch] = std::vector<std::vector<TrkStrawMatInfo>>();
       _allTSHIMCs[i_branch] = std::vector<std::vector<TrkStrawHitInfoMC>>();
-
+      std::cout << "[EventNtupleMaker Constructor] Finished creating track straw hit info structs for branch " << i_branchConfig.branch() << "." << std::endl;
       std::vector<std::vector<MVAResultInfo>> trkQualResults;
       for (size_t i_trkQualTag = 0; i_trkQualTag < i_branchConfig.trkQualTags().size(); ++i_trkQualTag) {
         trkQualResults.emplace_back(std::vector<MVAResultInfo>());
       }
       _allTrkQualResults[i_branch] = trkQualResults;
-
+      std::cout << "[EventNtupleMaker Constructor] Finished creating track quality info structs for branch " << i_branchConfig.branch() << "." << std::endl;
       std::vector<std::vector<MVAResultInfo>> trkPIDResults;
       for (size_t i_trkPIDTag = 0; i_trkPIDTag < i_branchConfig.trkPIDTags().size(); ++i_trkPIDTag) {
         trkPIDResults.emplace_back(std::vector<MVAResultInfo>());
       }
       _allTrkPIDResults[i_branch] = trkPIDResults;
 
-
+      std::cout << "[EventNtupleMaker Constructor] Finished creating track PID info structs for branch " << i_branchConfig.branch() << "." << std::endl;
       if(_conf.extraMCStepTags(_extraMCStepTags)){
         for (BranchIndex i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {
           for (StepCollIndex i_extraMCStepTag = 0; i_extraMCStepTag < _extraMCStepTags.size(); ++i_extraMCStepTag) {
@@ -471,6 +479,12 @@ namespace mu2e {
         }
       }
     }
+    
+    // Diagnostic: print configuration flags for calorimeter MC info
+    std::cout << "[EventNtupleMaker Constructor] Calorimeter configuration:" << std::endl;
+    std::cout << "  fillCaloDigisMC=" << _fillcalodigismc << std::endl;
+    std::cout << "  fillCaloDigiSimInfos=" << _fillcalodigisiminfos << std::endl;
+    std::cout << "  caloShowerSimTag=" << conf().caloShowerSimTag() << std::endl;
   }
 
   void EventNtupleMaker::beginJob( ){
@@ -577,6 +591,12 @@ namespace mu2e {
     }
     if (_fillcalodigis){
       _ntuple->Branch("calodigis.",&_caloDIs,_buffsize,_splitlevel);
+    }
+    if (_fillcalodigismc){
+      _ntuple->Branch("calodigismc.",&_caloDigiMCIs,_buffsize,_splitlevel);
+    }
+    if (_fillcalodigisiminfos){
+      _ntuple->Branch("calodigisim.",&_caloDigiSIMCs,_buffsize,_splitlevel);
     }
     // Calorimeter MC
     if (_fillmc) {
@@ -818,10 +838,17 @@ namespace mu2e {
     if (_fillcaloclustersmc) { _caloCIMCs.clear(); }
     if (_fillcalohitsmc) { _caloHIMCs.clear(); }
     if (_fillcalosiminfos) { _caloSIMCs.clear(); }
+    if (_fillcalodigisiminfos) { _caloDigiSIMCs.clear(); }
+    if (_fillcalodigismc) { _caloDigiMCIs.clear(); }
     _caloCIs.clear();
     _caloHIs.clear();
     _caloRDIs.clear();
     _caloDIs.clear();
+
+    // Retrieve CaloShowerSim collection for both caloDigisMC and caloDigiSimInfos branches
+    if (_fillcalodigismc || _fillcalodigisiminfos) {
+      event.getByLabel(_conf.caloShowerSimTag(),_caloShowerSim);
+    }
 
     if (_fillcaloclustersmc){
       for (const auto& clustermc : *_ccmcch.product()){
@@ -842,6 +869,14 @@ namespace mu2e {
     if (_fillcalosiminfos){
       for (const auto& clustermc : *_ccmcch.product()){
         _infoMCStructHelper.fillCaloSimInfos(clustermc,_caloSIMCs);
+      }
+    }
+    std::cout<< "[EventNtupleMaker::analyze] fillCaloDigiSimInfos=" << _fillcalodigisiminfos << " caloShowerSim.isValid()=" << _caloShowerSim.isValid() << std::endl;
+    if (_fillcalodigisiminfos){
+      if (_caloShowerSim.isValid()){
+        for (const auto& showerSim : *_caloShowerSim.product()){
+          _infoMCStructHelper.fillCaloDigiSimInfos(showerSim,_caloDigiSIMCs);
+        }
       }
     }
 
@@ -949,6 +984,20 @@ namespace mu2e {
               _infoStructHelper.fillCaloDigiInfo(digi,_caloDIs);
             }
           }
+        }
+      }
+
+      // Fill CaloDigisMC branch
+      if (_fillcalodigismc){
+        std::cout << "[EventNtupleMaker] Attempting to fill caloDigisMC branch" << std::endl;
+        if (_caloShowerSim.isValid()){
+          std::cout << "[EventNtupleMaker] CaloShowerSim collection found with " << _caloShowerSim->size() << " entries" << std::endl;
+          for (const auto& showerSim : *_caloShowerSim.product()){
+            _infoMCStructHelper.fillCaloDigiMCInfo(showerSim,_caloDigiMCIs);
+          }
+          std::cout << "[EventNtupleMaker] Filled caloDigisMC with " << _caloDigiMCIs.size() << " entries" << std::endl;
+        } else {
+          std::cout << "[EventNtupleMaker] WARNING: CaloShowerSim collection NOT found!" << std::endl;
         }
       }
 

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -438,7 +438,7 @@ namespace mu2e {
       if(_fillcalomc && _fillmc){
         _allMCTCHIs[i_branch] = std::vector<CaloClusterInfoMC>();
       }
-      std::cout << "[EventNtupleMaker Constructor] Finished creating track info structs for branch " << i_branchConfig.branch() << "." << std::endl;
+     
       RecoQualInfo rqi;
       _allRQIs.push_back(rqi);
 
@@ -446,20 +446,19 @@ namespace mu2e {
       _allTSHCIs[i_branch] = std::vector<std::vector<TrkStrawHitCalibInfo>>();
       _allTSMIs[i_branch] = std::vector<std::vector<TrkStrawMatInfo>>();
       _allTSHIMCs[i_branch] = std::vector<std::vector<TrkStrawHitInfoMC>>();
-      std::cout << "[EventNtupleMaker Constructor] Finished creating track straw hit info structs for branch " << i_branchConfig.branch() << "." << std::endl;
+
       std::vector<std::vector<MVAResultInfo>> trkQualResults;
       for (size_t i_trkQualTag = 0; i_trkQualTag < i_branchConfig.trkQualTags().size(); ++i_trkQualTag) {
         trkQualResults.emplace_back(std::vector<MVAResultInfo>());
       }
       _allTrkQualResults[i_branch] = trkQualResults;
-      std::cout << "[EventNtupleMaker Constructor] Finished creating track quality info structs for branch " << i_branchConfig.branch() << "." << std::endl;
+
       std::vector<std::vector<MVAResultInfo>> trkPIDResults;
       for (size_t i_trkPIDTag = 0; i_trkPIDTag < i_branchConfig.trkPIDTags().size(); ++i_trkPIDTag) {
         trkPIDResults.emplace_back(std::vector<MVAResultInfo>());
       }
       _allTrkPIDResults[i_branch] = trkPIDResults;
 
-      std::cout << "[EventNtupleMaker Constructor] Finished creating track PID info structs for branch " << i_branchConfig.branch() << "." << std::endl;
       if(_conf.extraMCStepTags(_extraMCStepTags)){
         for (BranchIndex i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {
           for (StepCollIndex i_extraMCStepTag = 0; i_extraMCStepTag < _extraMCStepTags.size(); ++i_extraMCStepTag) {

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -479,12 +479,6 @@ namespace mu2e {
         }
       }
     }
-    
-    // Diagnostic: print configuration flags for calorimeter MC info
-    std::cout << "[EventNtupleMaker Constructor] Calorimeter configuration:" << std::endl;
-    std::cout << "  fillCaloDigisMC=" << _fillcalodigismc << std::endl;
-    std::cout << "  fillCaloDigiSimInfos=" << _fillcalodigisiminfos << std::endl;
-    std::cout << "  caloShowerSimTag=" << conf().caloShowerSimTag() << std::endl;
   }
 
   void EventNtupleMaker::beginJob( ){
@@ -871,7 +865,6 @@ namespace mu2e {
         _infoMCStructHelper.fillCaloSimInfos(clustermc,_caloSIMCs);
       }
     }
-    std::cout<< "[EventNtupleMaker::analyze] fillCaloDigiSimInfos=" << _fillcalodigisiminfos << " caloShowerSim.isValid()=" << _caloShowerSim.isValid() << std::endl;
     if (_fillcalodigisiminfos){
       if (_caloShowerSim.isValid()){
         for (const auto& showerSim : *_caloShowerSim.product()){
@@ -989,15 +982,10 @@ namespace mu2e {
 
       // Fill CaloDigisMC branch
       if (_fillcalodigismc){
-        std::cout << "[EventNtupleMaker] Attempting to fill caloDigisMC branch" << std::endl;
         if (_caloShowerSim.isValid()){
-          std::cout << "[EventNtupleMaker] CaloShowerSim collection found with " << _caloShowerSim->size() << " entries" << std::endl;
           for (const auto& showerSim : *_caloShowerSim.product()){
             _infoMCStructHelper.fillCaloDigiMCInfo(showerSim,_caloDigiMCIs);
           }
-          std::cout << "[EventNtupleMaker] Filled caloDigisMC with " << _caloDigiMCIs.size() << " entries" << std::endl;
-        } else {
-          std::cout << "[EventNtupleMaker] WARNING: CaloShowerSim collection NOT found!" << std::endl;
         }
       }
 

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -17,6 +17,8 @@
 #include "Offline/GlobalConstantsService/inc/PhysicsParams.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
+#include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
+#include "Offline/CalorimeterGeom/inc/Crystal.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Principal/Event.h"
@@ -411,6 +413,17 @@ namespace mu2e {
     calodigimc.eprimary = 0.0;
     calodigimc.tprimary = 0.0;
     calodigimc.crystalID_ = shower.crystalID();
+    
+    // Get crystal position from geometry
+
+    mu2e::Calorimeter const &cal = *(mu2e::GeomHandle<mu2e::Calorimeter>());
+    GeomHandle<DetectorSystem> det;
+    Crystal const &crystal = cal.crystal(calodigimc.crystalID_);
+    CLHEP::Hep3Vector position = crystal.position();
+    CLHEP::Hep3Vector pos_detector = det->toDetector(position);
+    calodigimc.posX_ = pos_detector.x();
+    calodigimc.posY_ = pos_detector.y();
+    calodigimc.diskID_ = crystal.diskID();
     
     if (calodigimc.nsim > 0 && steps.front()){
       calodigimc.eprimary = steps.front()->energyDepG4();

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -400,6 +400,62 @@ namespace mu2e {
     chimcs.push_back(chimc);
   }
 
+  void InfoMCStructHelper::fillCaloDigiMCInfo(CaloShowerSim const& shower, std::vector<CaloDigiMCInfo>& calodigimcs) {
+    CaloDigiMCInfo calodigimc;
+    auto const& steps = shower.caloShowerSteps();
+    calodigimc.nsim = steps.size();
+    calodigimc.energyCorr_ = shower.energyDep();
+    calodigimc.timeCorr_ = shower.time();
+    calodigimc.eDepG4 = shower.energyDepG4();
+    calodigimc.eDep = shower.energyDep();
+    calodigimc.eprimary = 0.0;
+    calodigimc.tprimary = 0.0;
+    calodigimc.crystalID_ = shower.crystalID();
+    
+    if (calodigimc.nsim > 0 && steps.front()){
+      calodigimc.eprimary = steps.front()->energyDepG4();
+      calodigimc.tprimary = steps.front()->time();
+      
+      for (auto const& step : steps){
+        if (step && step->simParticle()){
+          auto simid = step->simParticle()->id().asInt();
+          calodigimc.tDeps.push_back(step->time());
+          calodigimc.eDeps.push_back(step->energyDepG4());
+          calodigimc.momentumIns.push_back(step->momentumIn());
+          calodigimc.simParticleIds.push_back(simid);
+          calodigimc.simRels.push_back(MCRelationship(step->simParticle(),steps.front()->simParticle()));
+        }
+      }
+    }
+    calodigimcs.push_back(calodigimc);
+  }
+
+  void InfoMCStructHelper::fillCaloDigiSimInfos(CaloShowerSim const& shower, std::vector<SimInfo>& cdsis) {
+    auto const& steps = shower.caloShowerSteps();
+    for (auto const& step : steps){
+      if (step && step->simParticle()){
+        auto simParticlePtr = step->simParticle();
+        int simid = simParticlePtr->id().asInt();
+
+        // Search that we didn't insert this particle already
+        bool already_added = false;
+        for (auto const& info : cdsis){
+          if (info.id == simid){
+            already_added = true;
+            break;
+          }
+        }
+        // It's new
+        if (!already_added){
+          SimInfo siminfo;
+          fillSimInfo(simParticlePtr, siminfo);
+          siminfo.index = cdsis.size();
+          cdsis.push_back(siminfo);
+        }
+      }
+    }
+  }
+
   void InfoMCStructHelper::fillCaloSimInfos(CaloClusterMC const& ccmc, std::vector<SimInfo>& csis) {
     auto const& edeps = ccmc.energyDeposits();
     for (auto const& edep : edeps){

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -7,8 +7,10 @@
 #include "KinKal/Trajectory/CentralHelix.hh"
 #include "Offline/Mu2eKinKal/inc/WireHitState.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
+#include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
+#include "Offline/CalorimeterGeom/inc/Crystal.hh"
 #include <cmath>
 #include <limits>
 
@@ -547,6 +549,18 @@ namespace mu2e {
     digiinfo.waveform_ = cdptr.waveform();
     digiinfo.peakpos_ = cdptr.peakpos();
     digiinfo.caloRecoDigiIdx_ = recodigiIdx;
+    
+    // Get crystal position from geometry
+    int cryID = digiinfo.SiPMID_ / 2;
+    mu2e::Calorimeter const &cal = *(mu2e::GeomHandle<mu2e::Calorimeter>());
+    GeomHandle<DetectorSystem> det;
+    Crystal const &crystal = cal.crystal(cryID);
+    CLHEP::Hep3Vector position = crystal.position();
+    CLHEP::Hep3Vector pos_detector = det->toDetector(position);
+    digiinfo.posX_ = pos_detector.x();
+    digiinfo.posY_ = pos_detector.y();
+    digiinfo.diskID_ = crystal.diskID();
+    
     digiinfos.push_back(digiinfo);
   }
 

--- a/src/classes.h
+++ b/src/classes.h
@@ -23,6 +23,7 @@
 #include "EventNtuple/inc/CaloClusterInfoMC.hh"
 #include "EventNtuple/inc/CaloClusterInfo.hh"
 #include "EventNtuple/inc/CaloHitInfoMC.hh"
+#include "EventNtuple/inc/CaloDigiMCInfo.hh"
 #include "EventNtuple/inc/CaloHitInfo.hh"
 #include "EventNtuple/inc/CaloRecoDigiInfo.hh"
 #include "EventNtuple/inc/CaloDigiInfo.hh"

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -59,6 +59,8 @@
   <class name="std::vector<mu2e::CaloRecoDigiInfo>" />
   <class name="mu2e::CaloDigiInfo" />
   <class name="std::vector<mu2e::CaloDigiInfo>" />
+    <class name="mu2e::CaloDigiMCInfo" />
+  <class name="std::vector<mu2e::CaloDigiMCInfo>" />
   <class name="mu2e::CrvHitInfoReco" />
   <class name="std::vector<mu2e::CrvHitInfoReco>" />
   <class name="mu2e::CrvHitInfoMC" />


### PR DESCRIPTION
This pull request introduces support for saving Monte Carlo (MC) truth information associated with calorimeter digis into the EventNtuple. The main changes include the addition of a new `CaloDigiMCInfo` struct, updates to the configuration and data handling in `EventNtupleMaker_module.cc`, and the implementation of helper methods to fill the new MC info. These changes allow for the optional storage of detailed MC truth for calorimeter digis and their associated simulation particles.

**New data structure for Calorimeter Digi MC information:**
- Added `CaloDigiMCInfo` struct to hold MC-truth information for calorimeter digis, including deposited energies, times, sim particle IDs, and relationships. (`inc/CaloDigiMCInfo.hh`, `src/classes.h`, `src/classes_def.xml`) [[1]](diffhunk://#diff-97556ea317c38a1406e62bf1129cffd9780831448eaee049f28f38594e1b2236R1-R34) [[2]](diffhunk://#diff-850f13ddb3096795c5cabe1807d009c576a9272b36b1948f19fa2623e7fd1e66R26) [[3]](diffhunk://#diff-6a20974c943b40b3ab3f2ceba0f0df60143cdeb37c9b6a830cc7b0e0c6fc5594R62-R63)

**EventNtupleMaker module enhancements:**
- Added configuration options and data members to enable writing out calorimeter digi MC information and associated sim info. (`src/EventNtupleMaker_module.cc`) [[1]](diffhunk://#diff-78220f79c572cf8e19524da7dd0e0a0c228019f8d60de7223e975694f93925fdR158-R164) [[2]](diffhunk://#diff-78220f79c572cf8e19524da7dd0e0a0c228019f8d60de7223e975694f93925fdR195) [[3]](diffhunk://#diff-78220f79c572cf8e19524da7dd0e0a0c228019f8d60de7223e975694f93925fdR307-R321) [[4]](diffhunk://#diff-78220f79c572cf8e19524da7dd0e0a0c228019f8d60de7223e975694f93925fdR391-R396)
- Updated the module to create, clear, and fill new branches for `CaloDigiMCInfo` and associated sim info, including retrieval of the necessary input collections. (`src/EventNtupleMaker_module.cc`) [[1]](diffhunk://#diff-78220f79c572cf8e19524da7dd0e0a0c228019f8d60de7223e975694f93925fdR589-R594) [[2]](diffhunk://#diff-78220f79c572cf8e19524da7dd0e0a0c228019f8d60de7223e975694f93925fdR835-R846) [[3]](diffhunk://#diff-78220f79c572cf8e19524da7dd0e0a0c228019f8d60de7223e975694f93925fdR868-R874) [[4]](diffhunk://#diff-78220f79c572cf8e19524da7dd0e0a0c228019f8d60de7223e975694f93925fdR983-R991)

**Helper methods for filling MC info:**
- Implemented `fillCaloDigiMCInfo` and `fillCaloDigiSimInfos` in `InfoMCStructHelper` to populate the new data structures from `CaloShowerSim` objects. (`src/InfoMCStructHelper.cc`, `inc/InfoMCStructHelper.hh`) [[1]](diffhunk://#diff-0494559d055a7f4efa5ebfec9a44f32ce74902a0e3c14e30f242b5f867cab9b2R403-R458) [[2]](diffhunk://#diff-7636ac6d0a766a0535a43423e50fe98b0477925bbe67d4c161086671252c1962R79-R80) [[3]](diffhunk://#diff-7636ac6d0a766a0535a43423e50fe98b0477925bbe67d4c161086671252c1962R12-R21)

**Configuration and FCL updates:**
- Updated FCL configuration to support toggling the new MC branches for calorimeter digis and to specify the relevant input tags. (`fcl/from_dig-calo.fcl`)

These changes collectively provide the infrastructure to store and access detailed MC truth for calorimeter digis in the EventNtuple, supporting future analysis and validation efforts.