### PR TITLE
version number

### DIFF
--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -486,7 +486,7 @@ namespace mu2e {
     _ntuple=tfs->make<TTree>("ntuple","Mu2e Event Ntuple");
     _hVersion = tfs->make<TH1I>("version", "version number",3,0,3);
     _hVersion->GetXaxis()->SetBinLabel(1, "major"); _hVersion->SetBinContent(1, 6);
-    _hVersion->GetXaxis()->SetBinLabel(2, "minor"); _hVersion->SetBinContent(2, 10);
+    _hVersion->GetXaxis()->SetBinLabel(2, "minor"); _hVersion->SetBinContent(2, 11);
     _hVersion->GetXaxis()->SetBinLabel(3, "patch"); _hVersion->SetBinContent(3, 0);
     _hProcEvents = tfs->make<TH1I>("n_proc_events", "number of processed events", 1,0,1);
     // add event info branch


### PR DESCRIPTION
This pull request makes a minor version update to the event ntuple versioning in the `EventNtupleMaker_module.cc` file. The change increments the "minor" version number from 10 to 11 in the version histogram.

- Versioning update:
  * Incremented the "minor" version number from 10 to 11 in the `_hVersion` histogram within `EventNtupleMaker_module.cc`.