### PR TITLE
calo branches no longer require strict hierarchy: all digis/recodigis…

### DIFF
--- a/fcl/from_mcs-Run1B.fcl
+++ b/fcl/from_mcs-Run1B.fcl
@@ -1,21 +1,13 @@
 # we start from mcs-extracted since Run-1B wants the straight line track fit
 #include "EventNtuple/fcl/from_mcs-extracted.fcl"
 
+physics.analyzers.EventNtuple.FillMCInfo : true
 physics.analyzers.EventNtuple.StepPointMCTags : [ "compressRecoMCs:virtualdetector" ] # we add the mcsteps_virtualdetector branch
 physics.analyzers.EventNtuple.FillTimeClusterInfo : true
 physics.analyzers.EventNtuple.TimeClustersTag : "SimpleTimeCluster" # Store time clusters for straight line track finding
-
-physics.analyzers.EventNtuple.FillCaloClusters  : true
-physics.analyzers.EventNtuple.FillCaloHits      : true
-physics.analyzers.EventNtuple.FillCaloRecoDigis : false
-physics.analyzers.EventNtuple.FillCaloDigis     : true
-
-physics.analyzers.EventNtuple.FillMCInfo         : true
-physics.analyzers.EventNtuple.FillCaloMC         : true
+physics.analyzers.EventNtuple.FillCaloMC : true
 physics.analyzers.EventNtuple.FillCaloClustersMC : true
-physics.analyzers.EventNtuple.FillCaloHitsMC     : true
-physics.analyzers.EventNtuple.FillCaloSimInfos   : true
-
+physics.analyzers.EventNtuple.FillCaloSimInfos : true
 services.GeometryService.inputFile : "Offline/Mu2eG4/geom/geom_common.txt" # we can use the standard geometry
 
-physics.EventNtupleEndPath : [ EventNtuple ] # add back genCountLogger
+physics.EventNtupleEndPath : [ @sequence::EventNtuple.EndPath ] # add back genCountLogger

--- a/fcl/from_mcs-Run1B.fcl
+++ b/fcl/from_mcs-Run1B.fcl
@@ -1,13 +1,21 @@
 # we start from mcs-extracted since Run-1B wants the straight line track fit
 #include "EventNtuple/fcl/from_mcs-extracted.fcl"
 
-physics.analyzers.EventNtuple.FillMCInfo : true
 physics.analyzers.EventNtuple.StepPointMCTags : [ "compressRecoMCs:virtualdetector" ] # we add the mcsteps_virtualdetector branch
 physics.analyzers.EventNtuple.FillTimeClusterInfo : true
 physics.analyzers.EventNtuple.TimeClustersTag : "SimpleTimeCluster" # Store time clusters for straight line track finding
-physics.analyzers.EventNtuple.FillCaloMC : true
+
+physics.analyzers.EventNtuple.FillCaloClusters  : true
+physics.analyzers.EventNtuple.FillCaloHits      : true
+physics.analyzers.EventNtuple.FillCaloRecoDigis : false
+physics.analyzers.EventNtuple.FillCaloDigis     : true
+
+physics.analyzers.EventNtuple.FillMCInfo         : true
+physics.analyzers.EventNtuple.FillCaloMC         : true
 physics.analyzers.EventNtuple.FillCaloClustersMC : true
-physics.analyzers.EventNtuple.FillCaloSimInfos : true
+physics.analyzers.EventNtuple.FillCaloHitsMC     : true
+physics.analyzers.EventNtuple.FillCaloSimInfos   : true
+
 services.GeometryService.inputFile : "Offline/Mu2eG4/geom/geom_common.txt" # we can use the standard geometry
 
-physics.EventNtupleEndPath : [ @sequence::EventNtuple.EndPath ] # add back genCountLogger
+physics.EventNtupleEndPath : [ EventNtuple ] # add back genCountLogger

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -286,7 +286,7 @@ EventNtupleMaker : {
   FillTimeClusterInfo : false
   CaloClustersTag : "CaloClusterMaker"
   CaloHitsTag : "CaloHitMaker"
-  CaloRecoDigisTag : ""
+  CaloRecoDigisTag : "CaloRecoDigiMaker"
   CaloDigisTag : "SelectReco"
   FillCaloClusters : true
   FillCaloHits : true
@@ -315,6 +315,7 @@ EventNtupleMaker : {
   PrimaryParticleTag : "compressRecoMCs"
   KalSeedMCAssns : "SelectReco"
   CaloClusterMCTag : "compressRecoMCs"
+  CaloHitMCTag : "compressRecoMCs"
   InfoMCStructHelper : {
     SimParticleCollectionTag : "compressRecoMCs"
     MinGoodMomFraction : 0.9

--- a/helper/ntuplehelper.py
+++ b/helper/ntuplehelper.py
@@ -246,12 +246,11 @@ class nthelper:
         else:
             print("## Calorimeter Branches\n")
             print("These branches are vectors of calorimeter clusters/hits/recodigis/digis that happened during the event.")
-            print("The branch is empty if there are no calo cluster during the event.\n")
             print("While each branch can be read independently, i.e. all the hits of the event, each element contains indexes to the other branches for parentage link.")
             print("The cluster element contains the vector \'hits_\' containing the indexes of the hits branch belonging to this cluster.")
             print("Similarly, each hit contains the indexes of its two recodigis (left and right channels) and the index of its parent cluster.")
             print("Example: cluster 3 has hits_ = {12, 13, 14, 15}. Each of those hits will have \'clusterIdx_\' = 3.")
-            print("Calo hits have the crystal (x,y,z) position saved. Frame origin is center of tracker.")
+            print("Calo digis and hits have the crystal (x,y,z) position saved. Frame origin is center of tracker.")
             print("| branch | structure | explanation | leaf information |")
             print("|--------|-----------|-------------|------------------|")
         for branch in self.calo_branches:

--- a/inc/CaloClusterInfoMC.hh
+++ b/inc/CaloClusterInfoMC.hh
@@ -7,6 +7,7 @@
 namespace mu2e
 {
   struct CaloClusterInfoMC {
+    int nhits; // number of hitmc associated with this cluster
     int nsim; // # of sim particles associated with this cluster
     float etot; // total true energy from all particles in this cluster
     float tavg; // average time over all particles

--- a/inc/CaloDigiInfo.hh
+++ b/inc/CaloDigiInfo.hh
@@ -5,22 +5,32 @@
 #define CaloDigiInfo_HH
 
 #include <vector>
+#include "Offline/RecoDataProducts/inc/CaloDigi.hh"
 
 namespace mu2e
 {
   struct CaloDigiInfo {
 
     int                 SiPMID_;           // Offline SiPM ID number
-    int                 diskID_;           // Offline disk ID number
     int                 t0_;               // Time of first waveform sample
     std::vector<int>    waveform_;         // Waveform
     int                 peakpos_;          // Waveform index of peak
-    int                 caloRecoDigiIdx_;  // RecoDigi index
-    float               posX_;             // Crystal x position in detector frame
-    float               posY_;             // Crystal y position in detector frame
 
-    CaloDigiInfo() : SiPMID_(-1), t0_(0), waveform_(), peakpos_(0), caloRecoDigiIdx_(-1), posX_(0.0), posY_(0.0) {}
+    // not in dataproduct
+    int                 diskID_;           // Offline disk ID number
+    int                 caloRecoDigiIdx_;  // RecoDigi index
+    int                 peakval_;          // Waveform value at peak
+    XYZVectorF          crystalPos_;       // Crystal position
+
+    CaloDigiInfo() : SiPMID_(-1), t0_(0), waveform_(), peakpos_(0), diskID_(-1), caloRecoDigiIdx_(-1), peakval_(0), crystalPos_() {}
     void reset() { *this = CaloDigiInfo(); }
+    
+    bool operator== (const CaloDigi& other) const {
+      return SiPMID_          == other.SiPMID()  &&
+             t0_              == other.t0()      &&
+             peakpos_         == other.peakpos() &&
+             waveform_.size() == other.waveform().size(); //no need to check the entire waveform
+    }
   };
 }
 #endif

--- a/inc/CaloHitInfo.hh
+++ b/inc/CaloHitInfo.hh
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include "EventNtuple/inc/RootVectors.hh"
+#include "Offline/RecoDataProducts/inc/CaloHit.hh"
 
 namespace mu2e
 {
@@ -18,12 +19,23 @@ namespace mu2e
     float             eDep_;                // Hit energy
     float             eDepErr_;             // Hit energy error
     std::vector<int>  recoDigis_;           // vector of branch indices of reco digis
-    int               clusterIdx_;          // Cluster index
 
+    // not in dataproduct
+    int               clusterIdx_;          // Cluster index
     XYZVectorF        crystalPos_;          // Crystal position
 
     CaloHitInfo() : crystalId_(0), nSiPMs_(0), time_(0.0), timeErr_(0.0), eDep_(0.0), eDepErr_(0.0), recoDigis_(), clusterIdx_(-1), crystalPos_() {}
     void reset() { *this = CaloHitInfo(); }
+
+    bool operator== (const CaloHit& other) const {
+      const double eps = 1e-9;
+      return crystalId_       == other.crystalID()        &&
+             nSiPMs_          == other.nSiPMs()           &&
+             std::abs(time_    - other.time()) < eps      &&
+             std::abs(timeErr_ - other.timeErr()) < eps   &&
+             std::abs(eDep_    - other.energyDep()) < eps &&
+             std::abs(eDepErr_ - other.energyDepErr()) < eps;
+    }
   };
 }
 #endif

--- a/inc/CaloHitInfoMC.hh
+++ b/inc/CaloHitInfoMC.hh
@@ -4,10 +4,13 @@
 #ifndef CaloHitInfoMC_HH
 #define CaloHitInfoMC_HH
 #include "Offline/MCDataProducts/inc/MCRelationship.hh"
+#include "Offline/MCDataProducts/inc/CaloHitMC.hh"
+
 namespace mu2e
 {
   struct CaloHitInfoMC {
 
+    int crystalID_; // Crystal ID of the hit
     int nsim; // # of sim particles associated with this hit
     float eDep; // total (corrected) deposited energy in the hit
     float eDepG4; // total G4 deposited energy in the hit
@@ -20,9 +23,25 @@ namespace mu2e
     std::vector<MCRelationship> simRels; // relationship to the particle that deposited the most energy in the calo Hit
     int clusterIdx_; // Cluster index
 
-    CaloHitInfoMC() : nsim(0), eDep(0.0), eDepG4(0.0), eprimary(0.0), tprimary(0.0), clusterIdx_(-1){}
+    CaloHitInfoMC() : crystalID_(0), nsim(0), eDep(0.0), eDepG4(0.0), eprimary(0.0), tprimary(0.0), clusterIdx_(-1){}
 
     void reset() { *this = CaloHitInfoMC(); }
+
+    bool operator== (const CaloHitMC& other) const {
+      const double eps = 1e-9;
+      auto const& edeps = other.energyDeposits();
+      bool same1 = crystalID_     == other.crystalID()             &&
+                   nsim           == int(edeps.size())             &&
+                   std::abs(eDep   - other.totalEnergyDep()) < eps &&
+                   std::abs(eDepG4 - other.totalEnergyDepG4()) < eps;
+      if (nsim > 0){ //Only compare first edep if exists
+        return same1                                                &&
+               std::abs(eprimary - edeps.front().energyDep()) < eps &&
+               std::abs(tprimary - edeps.front().time()) < eps;
+      } else {
+        return same1;
+      }
+    }
   };
 }
 #endif

--- a/inc/CaloRecoDigiInfo.hh
+++ b/inc/CaloRecoDigiInfo.hh
@@ -7,6 +7,7 @@
 #include "CLHEP/Vector/ThreeVector.h"
 #include "CLHEP/Units/PhysicalConstants.h"
 #include <vector>
+#include "Offline/RecoDataProducts/inc/CaloRecoDigi.hh"
 
 namespace mu2e
 {
@@ -20,10 +21,24 @@ namespace mu2e
     unsigned            ndf_;              // Fit NDF
     bool                pileUp_;           // Flag indicating if the hit is affected by pile-up
     int                 caloDigiIdx_;      // Index to the associated CaloDigi
-    int                 caloHitIdx_;       // Hit index
 
-    CaloRecoDigiInfo() : eDep_(0.0), eDepErr_(0.0), time_(0.0), timeErr_(0.0), chi2_(0.0), ndf_(0), pileUp_(false), caloDigiIdx_(-1), caloHitIdx_(-1) {}
+    // not in dataproduct
+    int                 caloHitIdx_;       // Hit index
+    int                 SiPMID_;           // Offline SiPM ID number 
+
+    CaloRecoDigiInfo() : eDep_(0.0), eDepErr_(0.0), time_(0.0), timeErr_(0.0), chi2_(0.0), ndf_(0), pileUp_(false), caloDigiIdx_(-1), caloHitIdx_(-1), SiPMID_(0) {}
     void reset() { *this = CaloRecoDigiInfo(); }
+    
+    bool operator== (const CaloRecoDigi& other) const {
+      const double eps = 1e-9;
+      return std::abs(eDep_    - other.energyDep())    < eps &&
+             std::abs(eDepErr_ - other.energyDepErr()) < eps &&
+             std::abs(time_    - other.time())    < eps &&
+             std::abs(timeErr_ - other.timeErr()) < eps &&
+             std::abs(chi2_    - other.chi2())    < eps &&
+             ndf_             == other.ndf()            &&
+             pileUp_          == other.pileUp();
+    }
   };
 }
 #endif

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -75,7 +75,7 @@ namespace mu2e {
       void fillVDInfo(KalSeed const& kseed, const KalSeedMC& kseedmc, std::vector<std::vector<MCStepInfo>>& all_vdinfos);
       void fillHitInfoMCs(const KalSeed& kseed, const KalSeedMC& kseedmc, std::vector<std::vector<TrkStrawHitInfoMC>>& all_tshinfomcs);
       void fillCaloClusterInfoMC(CaloClusterMC const& ccmc, std::vector<CaloClusterInfoMC>& ccimc);
-      void fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimc, int clusterIdx);
+      void fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimc, int clusterIdx = -1);
       void fillCaloDigiMCInfo(CaloShowerSim const& shower, std::vector<CaloDigiMCInfo>& calodigimc);
       void fillCaloDigiSimInfos(CaloShowerSim const& shower, std::vector<SimInfo>& cdsis);
       void fillCaloSimInfos(CaloClusterMC const& ccmc, std::vector<SimInfo>& csis);

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -196,6 +196,7 @@ namespace mu2e {
         fhicl::Atom<bool> fillCaloSimInfos{ Name("FillCaloSimInfos"),Comment("Fill Sim particles information associated with calo clusters"), true};
         fhicl::Atom<bool> fillCaloDigiSimInfos{ Name("FillCaloDigiSimInfos"),Comment("Fill Sim particles information associated with calo digis"), true};
         fhicl::Atom<art::InputTag> caloClusterMCTag{Name("CaloClusterMCTag"), Comment("Tag for CaloClusterMCCollection") ,art::InputTag()};
+        fhicl::Atom<art::InputTag> caloHitMCTag{Name("CaloHitMCTag"), Comment("Tag for CaloHitMCCollection") ,art::InputTag()};
         // CRV MC
         fhicl::Atom<art::InputTag> crvCoincidenceMCsTag{Name("CrvCoincidenceMCsTag"), Comment("Tag for CrvCoincidenceClusterMC Collection"), art::InputTag()};
         fhicl::Atom<art::InputTag> crvMCAssnsTag{ Name("CrvCoincidenceClusterMCAssnsTag"), Comment("art::InputTag for CrvCoincidenceClusterMCAssns")};
@@ -284,6 +285,7 @@ namespace mu2e {
       std::map<BranchIndex, std::vector<std::vector<MCStepInfo>>> _allMCVDInfos;
       bool _fillcalomc;
       art::Handle<CaloClusterMCCollection> _ccmcch;
+      art::Handle<CaloHitMCCollection> _chmcch;
       std::map<BranchIndex, std::vector<CaloClusterInfoMC>> _allMCTCHIs;
 
       // hit level info branches
@@ -742,7 +744,8 @@ namespace mu2e {
       event.getByLabel(_conf.kalSeedMCTag(),_ksmcah);
       event.getByLabel(_conf.simParticlesTag(),_simParticles);
       event.getByLabel(_conf.mcTrajectoriesTag(),_mcTrajectories);
-      if(_fillcalomc)event.getByLabel(_conf.caloClusterMCTag(),_ccmcch);
+      if(_fillcalomc || _fillcaloclustersmc)event.getByLabel(_conf.caloClusterMCTag(),_ccmcch);
+      if(_fillcalohitsmc)event.getByLabel(_conf.caloHitMCTag(),_chmcch);
     }
     // fill track counts
     for (BranchIndex i_branch = 0; i_branch < _allBranches.size(); ++i_branch) {
@@ -845,10 +848,17 @@ namespace mu2e {
     if (_fillcalosiminfos) { _caloSIMCs.clear(); }
     if (_fillcalodigisiminfos) { _caloDigiSIMCs.clear(); }
     if (_fillcalodigismc) { _caloDigiMCIs.clear(); }
-    _caloCIs.clear();
-    _caloHIs.clear();
-    _caloRDIs.clear();
-    _caloDIs.clear();
+    if (_fillcaloclusters) { _caloCIs.clear(); }
+    if (_fillcalohits) { _caloHIs.clear(); }
+    if (_fillcalorecodigis) { _caloRDIs.clear(); }
+    if (_fillcalodigis) { _caloDIs.clear(); }
+
+    // Fill Calo MC
+    if (_fillcalohitsmc){
+      for (const auto& hitmc : *_chmcch.product()){
+        _infoMCStructHelper.fillCaloHitInfoMC(hitmc,_caloHIMCs);
+      }
+    }
 
     // Retrieve CaloShowerSim collection for both caloDigisMC and caloDigiSimInfos branches
     if (_fillcalodigismc || _fillcalodigisiminfos) {
@@ -857,15 +867,24 @@ namespace mu2e {
 
     if (_fillcaloclustersmc){
       for (const auto& clustermc : *_ccmcch.product()){
-        int cluster_idx = _caloCIMCs.size();
+
         _infoMCStructHelper.fillCaloClusterInfoMC(clustermc,_caloCIMCs);
-      
-        if (_fillcalohitsmc){
+
+        //Find and link the existing hits
+        if (_fillcalohitsmc){ //TODO FIX this segm dumps
           for (const auto& hitmc : clustermc.caloHitMCs()){
-            int hit_idx = _caloHIMCs.size();
-            _infoMCStructHelper.fillCaloHitInfoMC(*hitmc,_caloHIMCs,cluster_idx);
-            //Update the cluster
-            _caloCIMCs.back().hits_.push_back(hit_idx);
+            for (uint hitIdx=0; hitIdx < _caloHIMCs.size(); hitIdx++){
+              
+              if (hitmc && _caloHIMCs[hitIdx] == *hitmc){
+                //Update the hit and cluster indexes
+                _caloHIMCs[hitIdx].clusterIdx_ = _caloCIMCs.size()-1;
+                _caloCIMCs.back().hits_.push_back(hitIdx);
+                break;
+              }
+            }
+          }
+          if (int(_caloCIMCs.back().hits_.size()) != _caloCIMCs.back().nhits){
+            throw cet::exception("EventNtuple") << "Could not find one or all CaloHitMCs linked to CaloClusterMC " << _caloCIMCs.size()-1 << "\n";
           }
         }
       }
@@ -884,6 +903,97 @@ namespace mu2e {
       }
     }
 
+    // Calorimeter reco branches
+
+    if (_fillcalodigis){
+      //Get the digis
+      event.getByLabel(_conf.caloDigisTag(),_caloDigis);
+      for (const auto& digi : *_caloDigis.product()){
+        _infoStructHelper.fillCaloDigiInfo(digi,_caloDIs);
+      }
+    }
+
+    if (_fillcalorecodigis){
+      //Get the recodigis
+      event.getByLabel(_conf.caloRecoDigisTag(),_caloRecoDigis);
+      for (const auto& recodigi : *_caloRecoDigis.product()){
+
+        _infoStructHelper.fillCaloRecoDigiInfo(recodigi,_caloRDIs);
+
+        //Find and link the existing digis
+        if (_fillcalodigis){
+          const auto& digi = recodigi.caloDigiPtr();
+          for (uint digiIdx=0; digiIdx < _caloDIs.size(); digiIdx++){
+        
+            if (_caloDIs[digiIdx] == *digi){
+              //Update the digi and recodigi indexes
+              _caloDIs[digiIdx].caloRecoDigiIdx_ = _caloRDIs.size()-1;
+              _caloRDIs.back().caloDigiIdx_ = digiIdx;
+              break;
+            }
+          }
+          if (_caloRDIs.back().caloDigiIdx_ < 0){
+            throw cet::exception("EventNtuple") << "Could not find CaloDigi linked to CaloRecoDigi " << _caloRDIs.size()-1 << "\n";
+          }
+        }
+      }
+    }
+
+    if (_fillcalohits){
+      //Get the hits
+      event.getByLabel(_conf.caloHitsTag(),_caloHits);
+      for (const auto& hit : *_caloHits.product()){
+
+        _infoStructHelper.fillCaloHitInfo(hit,_caloHIs);
+
+        //Find and link the existing recodigis
+        if (_fillcalorecodigis){
+          for (const auto& recodigi : hit.recoCaloDigis()){
+            for (uint recoDigiIdx=0; recoDigiIdx < _caloRDIs.size(); recoDigiIdx++){
+        
+              if (_caloRDIs[recoDigiIdx] == *recodigi){
+                //Update the recodigi and hit indexes
+                _caloRDIs[recoDigiIdx].caloHitIdx_ = _caloHIs.size()-1;
+                _caloHIs.back().recoDigis_.push_back(recoDigiIdx);
+                break;
+              }
+            }
+          }
+          if (int(_caloHIs.back().recoDigis_.size()) != _caloHIs.back().nSiPMs_){
+            throw cet::exception("EventNtuple") << "Could not find one or all CaloRecoDigi linked to CaloHit " << _caloHIs.size()-1 << "\n";
+          }
+        }
+      }
+    }
+
+    if (_fillcaloclusters){
+      //Get the clusters
+      event.getByLabel(_conf.caloClustersTag(),_caloClusters);
+      for (const auto& cluster : *_caloClusters.product()){
+
+        _infoStructHelper.fillCaloClusterInfo(cluster,_caloCIs);
+
+        //Find and link the existing hits
+        if (_fillcalohits){
+          for (const auto& hit : cluster.caloHitsPtrVector()){
+            for (uint hitIdx=0; hitIdx < _caloHIs.size(); hitIdx++){
+        
+              if (_caloHIs[hitIdx] == *hit){
+                //Update the hit and cluster indexes
+                _caloHIs[hitIdx].clusterIdx_ = _caloCIs.size()-1;
+                _caloCIs.back().hits_.push_back(hitIdx);
+                break;
+              }
+            }
+          }
+          if (_caloCIs.back().hits_.size() != _caloCIs.back().size_){
+            throw cet::exception("EventNtuple") << "Could not find one or all CaloHits linked to CaloCluster " << _caloCIs.size()-1 << "\n";
+          }
+        }
+      }
+    }
+
+/*
     //Fill clusters, hits, recodigis, and digis with hierarchy. If this code block is deemed too bulky, I can move it into InfoStructHelper. -pgirotti
     if (_fillcaloclusters){
 
@@ -1001,6 +1111,7 @@ namespace mu2e {
       }
 
     }
+*/
 
     // TODO we want MC information when we don't have a track
     // fill general CRV info

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -854,24 +854,36 @@ namespace mu2e {
     if (_fillcalodigis) { _caloDIs.clear(); }
 
     // Fill Calo MC
-    if (_fillcalohitsmc){
-      for (const auto& hitmc : *_chmcch.product()){
-        _infoMCStructHelper.fillCaloHitInfoMC(hitmc,_caloHIMCs);
-      }
-    }
 
     // Retrieve CaloShowerSim collection for both caloDigisMC and caloDigiSimInfos branches
     if (_fillcalodigismc || _fillcalodigisiminfos) {
       event.getByLabel(_conf.caloShowerSimTag(),_caloShowerSim);
     }
 
+    // Fill Calo MC Digis branch
+    if (_fillcalodigismc){
+      if (_caloShowerSim.isValid()){
+        for (const auto& showerSim : *_caloShowerSim.product()){
+          _infoMCStructHelper.fillCaloDigiMCInfo(showerSim,_caloDigiMCIs);
+        }
+      }
+    }
+
+    // Fill Calo MC Hits branch
+    if (_fillcalohitsmc){
+      for (const auto& hitmc : *_chmcch.product()){
+        _infoMCStructHelper.fillCaloHitInfoMC(hitmc,_caloHIMCs);
+      }
+    }
+
+    // Fill Calo MC Clusters branch
     if (_fillcaloclustersmc){
       for (const auto& clustermc : *_ccmcch.product()){
 
         _infoMCStructHelper.fillCaloClusterInfoMC(clustermc,_caloCIMCs);
 
         //Find and link the existing hits
-        if (_fillcalohitsmc){ //TODO FIX this segm dumps
+        if (_fillcalohitsmc){
           for (const auto& hitmc : clustermc.caloHitMCs()){
             for (uint hitIdx=0; hitIdx < _caloHIMCs.size(); hitIdx++){
               
@@ -895,6 +907,7 @@ namespace mu2e {
         _infoMCStructHelper.fillCaloSimInfos(clustermc,_caloSIMCs);
       }
     }
+    
     if (_fillcalodigisiminfos){
       if (_caloShowerSim.isValid()){
         for (const auto& showerSim : *_caloShowerSim.product()){
@@ -993,125 +1006,6 @@ namespace mu2e {
       }
     }
 
-/*
-    //Fill clusters, hits, recodigis, and digis with hierarchy. If this code block is deemed too bulky, I can move it into InfoStructHelper. -pgirotti
-    if (_fillcaloclusters){
-
-      //Get the clusters
-      event.getByLabel(_conf.caloClustersTag(),_caloClusters);
-      for (const auto& cluster : *_caloClusters.product()){
-
-        int cluster_idx = _caloCIs.size();
-        _infoStructHelper.fillCaloClusterInfo(cluster,_caloCIs);
-
-        if (_fillcalohits){
-          for (const auto& hit : cluster.caloHitsPtrVector()){
-
-            int hit_idx = _caloHIs.size();
-            _infoStructHelper.fillCaloHitInfo(*hit,_caloHIs,cluster_idx);
-
-            //Update the cluster
-            _caloCIs.back().hits_.push_back(hit_idx);
-
-            if (_fillcalorecodigis){
-              for (const auto& recodigi : hit->recoCaloDigis()){
-
-                int recodigi_idx = _caloRDIs.size();
-                _infoStructHelper.fillCaloRecoDigiInfo(*recodigi,_caloRDIs,hit_idx);
-
-                //Update the hit
-                _caloHIs.back().recoDigis_.push_back(recodigi_idx);
-
-                if (_fillcalodigis){
-                  const auto& digi = recodigi->caloDigiPtr();
-
-                  int digi_idx = _caloDIs.size();
-                  _infoStructHelper.fillCaloDigiInfo(*digi,_caloDIs,recodigi_idx);
-
-                  //Update the recodigi
-                  _caloRDIs.back().caloDigiIdx_ = digi_idx;
-
-                }
-              }
-            }
-          }
-        }
-      }
-    } else { //No clusters
-
-      if (_fillcalohits){
-        //Get the hits
-        event.getByLabel(_conf.caloHitsTag(),_caloHits);
-        for (const auto& hit : *_caloHits.product()){
-
-          int hit_idx = _caloHIs.size();
-          _infoStructHelper.fillCaloHitInfo(hit,_caloHIs);
-
-          if (_fillcalorecodigis){
-            for (const auto& recodigi : hit.recoCaloDigis()){
-
-              int recodigi_idx = _caloRDIs.size();
-              _infoStructHelper.fillCaloRecoDigiInfo(*recodigi,_caloRDIs,hit_idx);
-
-              //Update the hit
-              _caloHIs.back().recoDigis_.push_back(recodigi_idx);
-
-              if (_fillcalodigis){
-                const auto& digi = recodigi->caloDigiPtr();
-
-                int digi_idx = _caloDIs.size();
-                _infoStructHelper.fillCaloDigiInfo(*digi,_caloDIs,recodigi_idx);
-
-                //Update the recodigi
-                _caloRDIs.back().caloDigiIdx_ = digi_idx;
-
-              }
-            }
-          }
-        }
-      } else { //No hits
-
-        if (_fillcalorecodigis){
-          //Get the recodigis
-          event.getByLabel(_conf.caloRecoDigisTag(),_caloRecoDigis);
-          for (const auto& recodigi : *_caloRecoDigis.product()){
-
-            int recodigi_idx = _caloRDIs.size();
-            _infoStructHelper.fillCaloRecoDigiInfo(recodigi,_caloRDIs);
-
-            if (_fillcalodigis){
-              const auto& digi = recodigi.caloDigiPtr();
-              int digi_idx = _caloDIs.size();
-              _infoStructHelper.fillCaloDigiInfo(*digi,_caloDIs,recodigi_idx);
-
-              //Update the recodigi
-              _caloRDIs.back().caloDigiIdx_ = digi_idx;
-
-            }
-          }
-        } else { //No recodigis
-
-          if (_fillcalodigis){
-            //Get the digis
-            event.getByLabel(_conf.caloDigisTag(),_caloDigis);
-            for (const auto& digi : *_caloDigis.product()){
-              _infoStructHelper.fillCaloDigiInfo(digi,_caloDIs);
-            }
-          }
-        }
-      }
-
-      // Fill CaloDigisMC branch
-      if (_fillcalodigismc){
-        if (_caloShowerSim.isValid()){
-          for (const auto& showerSim : *_caloShowerSim.product()){
-            _infoMCStructHelper.fillCaloDigiMCInfo(showerSim,_caloDigiMCIs);
-          }
-        }
-      }
-
-    }
-*/
 
     // TODO we want MC information when we don't have a track
     // fill general CRV info

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -362,6 +362,7 @@ namespace mu2e {
   void InfoMCStructHelper::fillCaloClusterInfoMC(CaloClusterMC const& ccmc, std::vector<CaloClusterInfoMC>& ccimcs) {
     CaloClusterInfoMC ccimc;
     auto const& edeps = ccmc.energyDeposits();
+    ccimc.nhits = ccmc.caloHitMCs().size();
     ccimc.nsim = edeps.size();
     ccimc.etot = ccmc.totalEnergyDep();
     ccimc.tavg = 0.;
@@ -380,9 +381,10 @@ namespace mu2e {
     ccimcs.push_back(ccimc);
   }
 
-  void InfoMCStructHelper::fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimcs, int clusterIdx = -1) {
+  void InfoMCStructHelper::fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimcs, int clusterIdx) {
     CaloHitInfoMC chimc;
     auto const& edeps = chmc.energyDeposits();
+    chimc.crystalID_ = chmc.crystalID();
     chimc.nsim = edeps.size();
     chimc.eDep = chmc.totalEnergyDep();
     chimc.eDepG4 = chmc.totalEnergyDepG4();

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -11,6 +11,7 @@
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
 #include "Offline/CalorimeterGeom/inc/Crystal.hh"
+#include "Offline/DataProducts/inc/CaloConst.hh"
 #include <cmath>
 #include <limits>
 
@@ -523,9 +524,13 @@ namespace mu2e {
     hitinfo.eDep_ = chptr.energyDep();
     hitinfo.eDepErr_ = chptr.energyDepErr();
     hitinfo.clusterIdx_ = clusterIdx;
-    auto cal = GeomHandle<Calorimeter>();
-    auto& crystal = cal->crystal(chptr.crystalID());
-    hitinfo.crystalPos_ = cal->geomUtil().mu2eToTracker(crystal.position());
+
+    // Get crystal position from geometry
+    if (hitinfo.crystalId_ < CaloConst::_nCrystal){
+      auto cal = GeomHandle<Calorimeter>();
+      auto& crystal = cal->crystal(hitinfo.crystalId_);
+      hitinfo.crystalPos_ = cal->geomUtil().mu2eToTracker(crystal.position());
+    }
     hitinfos.push_back(hitinfo);
   }
 
@@ -552,11 +557,13 @@ namespace mu2e {
     digiinfo.caloRecoDigiIdx_ = recodigiIdx;
     
     // Get crystal position from geometry
-    int cryID = digiinfo.SiPMID_ / 2;
-    auto cal = GeomHandle<Calorimeter>();
-    auto& crystal = cal->crystal(cryID);
-    digiinfo.crystalPos_ = cal->geomUtil().mu2eToTracker(crystal.position());
-    digiinfo.diskID_ = crystal.diskID();
+    if (digiinfo.SiPMID_ < CaloConst::_nCrystalChannel){
+      int cryID = digiinfo.SiPMID_ / 2;
+      auto cal = GeomHandle<Calorimeter>();
+      auto& crystal = cal->crystal(cryID);
+      digiinfo.crystalPos_ = cal->geomUtil().mu2eToTracker(crystal.position());
+      digiinfo.diskID_ = crystal.diskID();
+    }
     digiinfo.peakval_ = cdptr.waveform()[cdptr.peakpos()];
     digiinfos.push_back(digiinfo);
   }

--- a/src/InfoStructHelper.cc
+++ b/src/InfoStructHelper.cc
@@ -539,6 +539,7 @@ namespace mu2e {
     recodigiinfo.ndf_ = crdptr.ndf();
     recodigiinfo.pileUp_ = crdptr.pileUp();
     recodigiinfo.caloHitIdx_ = hitIdx;
+    recodigiinfo.SiPMID_ = crdptr.SiPMID();
     recodigiinfos.push_back(recodigiinfo);
   }
 
@@ -552,15 +553,11 @@ namespace mu2e {
     
     // Get crystal position from geometry
     int cryID = digiinfo.SiPMID_ / 2;
-    mu2e::Calorimeter const &cal = *(mu2e::GeomHandle<mu2e::Calorimeter>());
-    GeomHandle<DetectorSystem> det;
-    Crystal const &crystal = cal.crystal(cryID);
-    CLHEP::Hep3Vector position = crystal.position();
-    CLHEP::Hep3Vector pos_detector = det->toDetector(position);
-    digiinfo.posX_ = pos_detector.x();
-    digiinfo.posY_ = pos_detector.y();
+    auto cal = GeomHandle<Calorimeter>();
+    auto& crystal = cal->crystal(cryID);
+    digiinfo.crystalPos_ = cal->geomUtil().mu2eToTracker(crystal.position());
     digiinfo.diskID_ = crystal.diskID();
-    
+    digiinfo.peakval_ = cdptr.waveform()[cdptr.peakpos()];
     digiinfos.push_back(digiinfo);
   }
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -58,6 +58,7 @@ helper.make_plugins( [
     rootlibs,
     'boost_filesystem',
     'mu2e_DataProducts',
+    'mu2e_MCDataProducts',
     'mu2e_RecoDataProducts',
     'mu2e_Mu2eUtilities',
     'mu2e_GeneralUtilities',


### PR DESCRIPTION
…/hits are filled in even if they don't belong to any higher-level class

Also, changed posX posY -> crystalPos in CaloDigiInfo
