### PR TITLE
Add back MC truth in extracted processing

### DIFF
--- a/fcl/from_mcs-extracted.fcl
+++ b/fcl/from_mcs-extracted.fcl
@@ -1,4 +1,4 @@
-#include "EventNtuple/fcl/from_mcs-mockdata_noMC.fcl"
+#include "EventNtuple/fcl/from_mcs-mockdata.fcl"
 
 physics.EventNtuplePath : [ @sequence::EventNtuple.PathExt ] # path for extracted position cosmics
 physics.analyzers.EventNtuple.branches : [ @local::Ext ]


### PR DESCRIPTION
Add MC truth processing by default. Without this EventNtuple throws, as the caloMC filling code doesn't respect the global flag.