### PR TITLE
Split vector<MCRelationship> branches for uproot

### DIFF
--- a/inc/CaloClusterInfoMC.hh
+++ b/inc/CaloClusterInfoMC.hh
@@ -14,7 +14,8 @@ namespace mu2e
     float eprimary; // primary particle true energy in this cluster
     float tprimary; // primary particle average time
     std::vector<int> simParticleIds; // list of simparticle ids
-    std::vector<MCRelationship> simRels; // relationship to the particle that deposited the most energy in the calo cluster
+    std::vector<int8_t> simRelRels; // relationship to the particle that deposited the most energy in the calo cluster (see MCRelationship for more details)
+    std::vector<int8_t> simRelRems; // distance of relationship to the particle that deposited the most energy in the calo cluster (see MCRelationship for more details)
     std::vector<int>  hits_; // vector of branch indices of hits in the cluster
     MCRelationship prel; // relationship of the cluster primary particle to the event primary
     CaloClusterInfoMC() : nsim(0), etot(0.0), tavg(0.0), eprimary(0.0), tprimary(0.0){}

--- a/inc/CaloDigiMCInfo.hh
+++ b/inc/CaloDigiMCInfo.hh
@@ -20,7 +20,8 @@ namespace mu2e
     std::vector<float> tDeps;           // list of times of energy deposits
     std::vector<float> momentumIns;     // list of the momentum of the SimParticle when entering in the disk
     std::vector<int> simParticleIds;    // list of simparticle ids
-    std::vector<MCRelationship> simRels;// relationship to the particle that deposited the most energy in the calo digi
+    std::vector<int8_t> simRelRels; // relationship to the particle that deposited the most energy in the calo digi (see MCRelationship for more details)
+    std::vector<int8_t> simRelRems; // distance of relationship to the particle that deposited the most energy in the calo digi (see MCRelationship for more details)
     int caloHitIdx_;                    // CaloHit index
     int crystalID_;                     // Crystal ID from CaloShowerSim
     int diskID_;           // Offline disk ID number

--- a/inc/CaloHitInfoMC.hh
+++ b/inc/CaloHitInfoMC.hh
@@ -20,7 +20,9 @@ namespace mu2e
     std::vector<float> tDeps; // list of times of energy deposits
     std::vector<float> momentumIns; // list of the momentum of the SimParticle when entering in the disk
     std::vector<int> simParticleIds; // list of simparticle ids
-    std::vector<MCRelationship> simRels; // relationship to the particle that deposited the most energy in the calo Hit
+    std::vector<int8_t> simRelRels; // relationship to the particle that deposited the most energy in the calo hit (see MCRelationship for more details)
+    std::vector<int8_t> simRelRems; // distance of relationship to the particle that deposited the most energy in the calo hit (see MCRelationship for more details)
+
     int clusterIdx_; // Cluster index
     int caloHitIdx_; // index into calohits branch, -1 if unset; calohitsmc is NOT index-aligned with calohits
 

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -374,7 +374,9 @@ namespace mu2e {
         ccimc.tavg += edep.time();
         auto simid = edep.sim()->id().asInt();
         ccimc.simParticleIds.push_back(simid);
-        ccimc.simRels.push_back(MCRelationship(edep.sim(),edeps.front().sim()));
+        MCRelationship simRel(edep.sim(),edeps.front().sim());
+        ccimc.simRelRels.push_back(simRel.relationship());
+        ccimc.simRelRems.push_back(simRel.removal());
       }
       ccimc.tavg /= ccimc.nsim;
     }
@@ -399,7 +401,10 @@ namespace mu2e {
         chimc.eDeps.push_back(edep.energyDep());
         chimc.momentumIns.push_back(edep.momentumIn());
         chimc.simParticleIds.push_back(simid);
-        chimc.simRels.push_back(MCRelationship(edep.sim(),edeps.front().sim()));
+        MCRelationship simRel(edep.sim(),edeps.front().sim());
+        chimc.simRelRels.push_back(simRel.relationship());
+        chimc.simRelRems.push_back(simRel.removal());
+
       }
     }
     chimcs.push_back(chimc);
@@ -439,7 +444,10 @@ namespace mu2e {
           calodigimc.eDeps.push_back(step->energyDepG4());
           calodigimc.momentumIns.push_back(step->momentumIn());
           calodigimc.simParticleIds.push_back(simid);
-          calodigimc.simRels.push_back(MCRelationship(step->simParticle(),steps.front()->simParticle()));
+          MCRelationship simRel(step->simParticle(),steps.front()->simParticle());
+          calodigimc.simRelRels.push_back(simRel.relationship());
+          calodigimc.simRelRems.push_back(simRel.removal());
+
         }
       }
     }


### PR DESCRIPTION
This PR splits leaves that are ```vector<MCRelationship>``` since uproot cannot read the branches that contain them