### PR TITLE
Flatten calo-entrant truth into calohitsmc.entrantSimIds

### DIFF
--- a/inc/CaloHitInfoMC.hh
+++ b/inc/CaloHitInfoMC.hh
@@ -21,6 +21,7 @@ namespace mu2e
     std::vector<float> momentumIns; // list of the momentum of the SimParticle when entering in the disk
     std::vector<int> simParticleIds; // list of simparticle ids
     std::vector<MCRelationship> simRels; // relationship to the particle that deposited the most energy in the calo Hit
+    std::vector<int> entrantSimIds; // calo-entrant (shower originator) SimParticle id per deposit, aligned with simParticleIds; filled only when calo.mc.entrantTag is configured
     int clusterIdx_; // Cluster index
     int caloHitIdx_; // index into calohits branch, -1 if unset; calohitsmc is NOT index-aligned with calohits
 

--- a/inc/InfoMCStructHelper.hh
+++ b/inc/InfoMCStructHelper.hh
@@ -19,6 +19,7 @@
 #include "EventNtuple/inc/CaloClusterInfoMC.hh"
 #include "EventNtuple/inc/CaloHitInfoMC.hh"
 #include "EventNtuple/inc/CaloDigiMCInfo.hh"
+#include "Offline/MCDataProducts/inc/CaloHitEntrant.hh"
 #include "EventNtuple/inc/MCStepInfo.hh"
 #include "EventNtuple/inc/MCStepSummaryInfo.hh"
 #include "EventNtuple/inc/SurfaceStepInfo.hh"
@@ -75,7 +76,7 @@ namespace mu2e {
       void fillVDInfo(KalSeed const& kseed, const KalSeedMC& kseedmc, std::vector<std::vector<MCStepInfo>>& all_vdinfos);
       void fillHitInfoMCs(const KalSeed& kseed, const KalSeedMC& kseedmc, std::vector<std::vector<TrkStrawHitInfoMC>>& all_tshinfomcs);
       void fillCaloClusterInfoMC(CaloClusterMC const& ccmc, std::vector<CaloClusterInfoMC>& ccimc);
-      void fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimc, int clusterIdx = -1);
+      void fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimc, int clusterIdx = -1, const CaloHitEntrant* entrant = nullptr);
       void fillCaloDigiMCInfo(CaloShowerSim const& shower, std::vector<CaloDigiMCInfo>& calodigimc);
       void fillCaloDigiSimInfos(CaloShowerSim const& shower, std::vector<SimInfo>& cdsis);
       void fillCaloSimInfos(CaloClusterMC const& ccmc, std::vector<SimInfo>& csis);

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -997,6 +997,16 @@ namespace mu2e {
         if(entrants->size() != _chmcch->size()){
           throw cet::exception("EventNtuple") << "CaloHitEntrantCollection size " << entrants->size() << " != CaloHitMCCollection size " << _chmcch->size() << "\n";
         }
+        // Source identity: each entrant carries a Ptr to the CaloHitMC it was
+        // computed for; require it to be entry i of the collection this fill
+        // iterates, so a product built from a different CaloHitMCCollection
+        // (or reordered) cannot be flattened silently.
+        for(size_t i = 0; i < entrants->size(); ++i){
+          const auto& hmcPtr = (*entrants)[i].caloHitMC();
+          if(hmcPtr.id() != _chmcch.id() || hmcPtr.key() != i){
+            throw cet::exception("EventNtuple") << "CaloHitEntrant " << i << " references CaloHitMC (ProductID " << hmcPtr.id() << ", key " << hmcPtr.key() << ") but this fill iterates (ProductID " << _chmcch.id() << ", key " << i << ")\n";
+          }
+        }
       }
       size_t entrantIdx = 0;
       for(const auto& hitmc : *_chmcch.product()){

--- a/src/EventNtupleMaker_module.cc
+++ b/src/EventNtupleMaker_module.cc
@@ -9,6 +9,7 @@
 #include "Offline/MCDataProducts/inc/KalSeedMC.hh"
 #include "Offline/MCDataProducts/inc/CaloClusterMC.hh"
 #include "Offline/MCDataProducts/inc/CaloHitMC.hh"
+#include "Offline/MCDataProducts/inc/CaloHitEntrant.hh"
 #include "Offline/MCDataProducts/inc/ProtonBunchTimeMC.hh"
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/RecoDataProducts/inc/KalSeedAssns.hh"
@@ -220,6 +221,7 @@ namespace mu2e {
           fhicl::Atom<bool>          fillDigis   {Name("fillDigis"),    Comment("Fill standalone calodigismc. branch")};
           fhicl::Atom<bool>          fillDigiSim {Name("fillDigiSim"),  Comment("Fill calodigisim. branch")};
           fhicl::Atom<art::InputTag> showerSimTag{Name("showerSimTag"), Comment("Tag for CaloShowerSim collection")};
+          fhicl::Atom<art::InputTag> entrantTag  {Name("entrantTag"),   Comment("Tag for CaloHitEntrantCollection (calo-entrant truth in calohitsmc.entrantSimIds); empty disables"), art::InputTag()};
         };
         fhicl::Table<MCConfig> mc{Name("mc"), Comment("Calorimeter MC filling options")};
       };
@@ -366,6 +368,7 @@ namespace mu2e {
       std::map<TrkFitBranchIndex, std::vector<std::vector<MCStepInfo>>> _allMCVDInfos;
       art::Handle<CaloClusterMCCollection> _ccmcch;
       art::Handle<CaloHitMCCollection> _chmcch;
+      art::Handle<CaloHitEntrantCollection> _caloEntrants;
       std::map<TrkFitBranchIndex, std::vector<CaloClusterInfoMC>> _allMCTCHIs;
       // hit level info branches
       std::map<TrkFitBranchIndex, std::vector<std::vector<TrkStrawHitInfo>>> _allTSHIs;
@@ -982,8 +985,23 @@ namespace mu2e {
       }
     }
     if(fillCaloHitsMC()){
+      // Optional calo-entrant truth: the CaloHitEntrantCollection is
+      // index-parallel to the CaloHitMCCollection by construction.
+      const CaloHitEntrantCollection* entrants = nullptr;
+      if(!_conf.calo().mc().entrantTag().empty()){
+        event.getByLabel(_conf.calo().mc().entrantTag(),_caloEntrants);
+        if(!_caloEntrants.isValid()){
+          throw cet::exception("EventNtuple") << "CaloHitEntrantCollection not found for entrantTag \"" << _conf.calo().mc().entrantTag().encode() << "\"\n";
+        }
+        entrants = _caloEntrants.product();
+        if(entrants->size() != _chmcch->size()){
+          throw cet::exception("EventNtuple") << "CaloHitEntrantCollection size " << entrants->size() << " != CaloHitMCCollection size " << _chmcch->size() << "\n";
+        }
+      }
+      size_t entrantIdx = 0;
       for(const auto& hitmc : *_chmcch.product()){
-        _infoMCStructHelper.fillCaloHitInfoMC(hitmc,_caloHIMCs);
+        _infoMCStructHelper.fillCaloHitInfoMC(hitmc,_caloHIMCs,-1,entrants ? &(*entrants)[entrantIdx] : nullptr);
+        ++entrantIdx;
       }
     }
     if(fillCaloClsMC()){

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -6,6 +6,7 @@
 #include "Offline/MCDataProducts/inc/StepPointMC.hh"
 #include "Offline/MCDataProducts/inc/SimParticle.hh"
 #include "Offline/MCDataProducts/inc/MCRelationship.hh"
+#include "cetlib_except/exception.h"
 
 #include "Offline/TrackerGeom/inc/Tracker.hh"
 #include "Offline/Mu2eUtilities/inc/TwoLinePCA.hh"
@@ -381,9 +382,13 @@ namespace mu2e {
     ccimcs.push_back(ccimc);
   }
 
-  void InfoMCStructHelper::fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimcs, int clusterIdx) {
+  void InfoMCStructHelper::fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimcs, int clusterIdx, const CaloHitEntrant* entrant) {
     CaloHitInfoMC chimc;
     auto const& edeps = chmc.energyDeposits();
+    if (entrant != nullptr && entrant->entrants.size() != edeps.size()) {
+      throw cet::exception("EventNtuple") << "CaloHitEntrant has " << entrant->entrants.size()
+          << " entrants but CaloHitMC has " << edeps.size() << " energy deposits\n";
+    }
     chimc.crystalID_ = chmc.crystalID();
     chimc.nsim = edeps.size();
     chimc.eDep = chmc.totalEnergyDep();
@@ -393,6 +398,7 @@ namespace mu2e {
     if (chimc.nsim > 0){
       chimc.eprimary = edeps.front().energyDep();
       chimc.tprimary = edeps.front().time();
+      size_t iedep = 0;
       for (auto const& edep : edeps){
         auto simid = edep.sim()->id().asInt();
         chimc.tDeps.push_back(edep.time());
@@ -400,6 +406,13 @@ namespace mu2e {
         chimc.momentumIns.push_back(edep.momentumIn());
         chimc.simParticleIds.push_back(simid);
         chimc.simRels.push_back(MCRelationship(edep.sim(),edeps.front().sim()));
+        // entrantSimIds aligned with simParticleIds; -1 marks a deposit the
+        // upstream CaloEntrantTruthMaker could not resolve
+        if (entrant != nullptr) {
+          const auto& ep = entrant->entrants[iedep];
+          chimc.entrantSimIds.push_back(ep.isNonnull() ? ep->id().asInt() : -1);
+        }
+        ++iedep;
       }
     }
     chimcs.push_back(chimc);

--- a/src/InfoMCStructHelper.cc
+++ b/src/InfoMCStructHelper.cc
@@ -385,8 +385,8 @@ namespace mu2e {
   void InfoMCStructHelper::fillCaloHitInfoMC(CaloHitMC const& chmc, std::vector<CaloHitInfoMC>& chimcs, int clusterIdx, const CaloHitEntrant* entrant) {
     CaloHitInfoMC chimc;
     auto const& edeps = chmc.energyDeposits();
-    if (entrant != nullptr && entrant->entrants.size() != edeps.size()) {
-      throw cet::exception("EventNtuple") << "CaloHitEntrant has " << entrant->entrants.size()
+    if (entrant != nullptr && entrant->entrants().size() != edeps.size()) {
+      throw cet::exception("EventNtuple") << "CaloHitEntrant has " << entrant->entrants().size()
           << " entrants but CaloHitMC has " << edeps.size() << " energy deposits\n";
     }
     chimc.crystalID_ = chmc.crystalID();
@@ -409,7 +409,7 @@ namespace mu2e {
         // entrantSimIds aligned with simParticleIds; -1 marks a deposit the
         // upstream CaloEntrantTruthMaker could not resolve
         if (entrant != nullptr) {
-          const auto& ep = entrant->entrants[iedep];
+          const auto& ep = entrant->entrants()[iedep];
           chimc.entrantSimIds.push_back(ep.isNonnull() ? ep->id().asInt() : -1);
         }
         ++iedep;


### PR DESCRIPTION
Companion to Mu2e/Offline#1911, and requires it (this uses the new CaloHitEntrant product), so I am leaving this as a draft until that one merges. The two together replace #366.

This adds an `entrantSimIds` branch to `calohitsmc`: per hit, the calo-entrant SimParticle ID for each contribution, aligned one-to-one with `simParticleIds`. A value of -1 means the producer had no entrant for that deposit.

The fill is controlled by a new `calo.mc.entrantTag` config which defaults to empty, meaning off. Existing configs are untouched and produce identical output. When the tag is set the fill is strict: a missing product, a wrong collection size, a per-hit count mismatch, or an entrant entry that does not reference the exact CaloHitMC being flattened (checked through the product's `Ptr<CaloHitMC>` back-reference, ProductID and index) is an exception, not a warning, so you cannot silently end up with half-filled or wrong-collection truth.

One scope note: `entrantSimIds` is aligned within `calohitsmc`. Matching `calohits` entries to `calohitsmc` entries is a separate, pre-existing question (`caloHitIdx_` / `crystalID_`, cf. 125a71a); this branch does not depend on that join and does not change it. If the `calohitsmc` ordering or the join ever changes, the new column just follows along.

Validation: 200 MDC2025 events (run 001430) with the producer plus this fill on current main. The flattened entrant IDs agree with my published Python pipeline for all 6,554 contributions (3,903/3,903 MC hits matched across ntuple formats). I also checked the April-format version of this change, where the downstream GNN graph labels come out byte-identical (341/341 disk-graphs); on current main I validated at the entrant-root level, since the reco/MC hit join is the separate question above.
